### PR TITLE
convert修改：添加.js后缀，替换wx:show属性

### DIFF
--- a/packages/taro-cli-convertor/src/util/index.ts
+++ b/packages/taro-cli-convertor/src/util/index.ts
@@ -42,6 +42,9 @@ function getRelativePath (
   }
   // 处理非正常路径，比如 a/b
   if (oriPath.indexOf('.') !== 0) {
+    if (oriPath.indexOf('/') !== -1 && oriPath.indexOf('@') === -1 && oriPath.lastIndexOf('.js') !== oriPath.length-3){
+      oriPath = oriPath + '.js'  // 不在这里返回    utils/auth -> utils/auth.js
+    }
     const vpath = path.resolve(sourceFilePath, '..', oriPath)
     if (fs.existsSync(vpath)) {
       return './' + oriPath

--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -92,6 +92,7 @@ export const WX_FOR_ITEM = 'wx:for-item'
 export const WX_FOR_INDEX = 'wx:for-index'
 export const WX_KEY = 'wx:key'
 export const WX_ELSE = 'wx:else'
+export const WX_SHOW = 'wx:show'
 
 export const wxTemplateCommand = [
   WX_IF,
@@ -163,7 +164,12 @@ export const createWxmlVistor = (
       if (nodeName === WX_KEY) {
         path.replaceWith(t.jSXIdentifier('key'))
       }
-      if (nodeName.startsWith('wx:') && !wxTemplateCommand.includes(nodeName)) {
+      if (nodeName === WX_SHOW){
+        path.replaceWith(t.jSXIdentifier(WX_IF)) // wx:show转换后不支持，不频繁切换的话wx:if可替代
+        // eslint-disable-next-line no-console
+        console.log(`属性  ${nodeName}不能编译,会被替换为wx:if`)
+      }
+      else if (nodeName.startsWith('wx:') && !wxTemplateCommand.includes(nodeName)) {
         // eslint-disable-next-line no-console
         console.log(`未知 wx 作用域属性： ${nodeName}，该属性会被移除掉。`)
         path.parentPath.remove()


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
1、convert相关代码内，引用导入添加.js后缀，避免编译时的模块找不到问题（导入utils/auth -> utils/auth.js）
2、convert相关代码内，属性wx:show属性替换为wx:if，避免编译报错（wx:show已无法在微信小程序官方文档搜索到）


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
