### PR TITLE
'修复转换时slot值为空的错误，为slot赋值taroslot'

### DIFF
--- a/packages/taroize/src/template.ts
+++ b/packages/taroize/src/template.ts
@@ -37,9 +37,9 @@ export function parseTemplate (path: NodePath<t.JSXElement>, dirPath: string) {
   }
   const openingElement = path.get('openingElement')
   const attrs = openingElement.get('attributes')
-  const is = attrs.find(attr => t.isJSXAttribute(attr) && t.isJSXIdentifier(attr.name) && attr.name.name === 'is')
-  const data = attrs.find(attr => t.isJSXAttribute(attr) && t.isJSXIdentifier(attr.name) && attr.name.name === 'data')
-  const name = attrs.find(attr => t.isJSXAttribute(attr) && t.isJSXIdentifier(attr.name) && attr.name.name === 'name')
+  const is = attrs.find(attr => t.isJSXAttribute(attr) && t.isJSXIdentifier(attr.get('name')) && t.isJSXAttribute(attr.node) && attr.node.name.name === 'is');
+  const data = attrs.find(attr => t.isJSXAttribute(attr) && t.isJSXIdentifier(attr.get('name')) && t.isJSXAttribute(attr.node) && attr.node.name.name === 'data');
+  const name = attrs.find(attr => t.isJSXAttribute(attr) && t.isJSXIdentifier(attr.get('name')) && t.isJSXAttribute(attr.node) && attr.node.name.name === 'name');
 
   const refIds = new Set<string>()
   const loopIds = new Set<string>() 
@@ -168,14 +168,19 @@ export function getWXMLsource (dirPath: string, src: string, type: string) {
 export function parseModule (jsx: NodePath<t.JSXElement>, dirPath: string, type: 'include' | 'import') {
   const openingElement = jsx.get('openingElement')
   const attrs = openingElement.get('attributes')
-  const src = attrs.find(attr => t.isJSXAttribute(attr) && t.isJSXIdentifier(attr.name) && attr.name.name === 'src')
+  //const src = attrs.find(attr => t.isJSXAttribute(attr) && t.isJSXIdentifier(attr.name) && attr.name.name === 'src')
+  //Fix
+  const src = attrs.find(attr => t.isJSXAttribute(attr) && t.isJSXIdentifier(attr.get('name')) && t.isJSXAttribute(attr.node) && attr.node.name.name === 'src')
   if (!src) {
     throw new Error(`${type} 标签必须包含 \`src\` 属性`)
   }
   if (extname(dirPath)) {
     dirPath = dirname(dirPath)
   }
-  const value = src.get('value')
+  if (!t.isJSXAttribute(src.node)) {
+    throw new Error(`${type} 标签src AST节点 必须包含node`)
+  }
+  const value = src.node.value
   if (!t.isStringLiteral(value)) {
     throw new Error(`${type} 标签的 src 属性值必须是一个字符串`)
   }

--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -201,27 +201,31 @@ export const createWxmlVistor = (
         const slotAttr = attrs.find(a => t.isJSXAttribute(a.node) && a.node?.name.name === 'slot')
         if (slotAttr && t.isJSXAttribute(slotAttr.node)) {
           const slotValue = slotAttr.node.value
+          let slotName = ''
           if (slotValue && t.isStringLiteral(slotValue)) {
-            const slotName = slotValue.value
-            const parentComponent = path.findParent(p => p.isJSXElement() && t.isJSXIdentifier(p.node.openingElement.name) && !DEFAULT_Component_SET.has(p.node.openingElement.name.name))
-            if (parentComponent && parentComponent.isJSXElement()) {
-              slotAttr.remove()
-              path.traverse({
-                JSXAttribute: jsxAttrVisitor
-              })
-              const block = buildBlockElement()
-              block.children = [cloneDeep(path.node)]
-              parentComponent.node.openingElement.attributes.push(
-                t.jSXAttribute(
-                  t.jSXIdentifier(buildSlotName(slotName)),
-                  t.jSXExpressionContainer(block)
-                )
-              )
-              path.remove()
-            }
+            slotName = slotValue.value
           } else {
-            throw codeFrameError(slotValue, 'slot 的值必须是一个字符串')
+            slotName = 'taroslot'
           }
+          const parentComponent = path.findParent(p => p.isJSXElement() && t.isJSXIdentifier(p.node.openingElement.name) && !DEFAULT_Component_SET.has(p.node.openingElement.name.name))
+          if (parentComponent && parentComponent.isJSXElement()) {
+            slotAttr.remove()
+            path.traverse({
+              JSXAttribute: jsxAttrVisitor
+            })
+            const block = buildBlockElement()
+            block.children = [cloneDeep(path.node)]
+            parentComponent.node.openingElement.attributes.push(
+              t.jSXAttribute(
+                t.jSXIdentifier(buildSlotName(slotName)),
+                t.jSXExpressionContainer(block)
+              )
+            )
+            path.remove()
+          }
+          /*} else {
+            throw codeFrameError(slotValue, 'slot 的值必须是一个字符串')
+          }*/
         }
         const tagName = jsxName.node.name
         if (tagName === 'Slot') {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
微信小程序支持slot标签的值为空，但转换工具对此无法转换
当检测到slot的值为空时，为slot赋值‘taroslot’


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [x] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
