### PR TITLE
fix: 微信小程序转taro时，wxs标签和wxs文件中getRegExp转换为new RegExp

### DIFF
--- a/packages/taro-transformer-wx/src/index.ts
+++ b/packages/taro-transformer-wx/src/index.ts
@@ -57,6 +57,7 @@ import {
   isContainJSXElement,
   replaceJSXTextWithTextComponent,
   setting} from './utils'
+import { traverseWxsFile } from './wxs'
 
 const template = require('@babel/template')
 
@@ -314,6 +315,12 @@ export default function transform (options: TransformOptions): TransformResult {
         resetTSClassProperty(mainClassNode.body.body as any)
       }
     }
+
+    // 对wxs文件进行转换
+    if (options.sourcePath.endsWith('.wxs')) {
+      return traverseWxsFile(ast, defaultResult)
+    }
+
     const code = generate(ast.program as any).code
     return {
       ...defaultResult,

--- a/packages/taro-transformer-wx/src/wxs.ts
+++ b/packages/taro-transformer-wx/src/wxs.ts
@@ -1,0 +1,42 @@
+import generate from '@babel/generator'
+import traverse, { Visitor } from '@babel/traverse'
+import * as t from '@babel/types'
+
+import { TransformResult } from './index'
+
+export function traverseWxsFile(ast: t.File, defaultResult: TransformResult) {
+  const vistor: Visitor = {
+    BlockStatement(path) {
+      path.scope.rename('wx', 'Taro')
+    },
+    Identifier(path) {
+      if (path.isReferenced() && path.node.name === 'wx') {
+        path.replaceWith(t.identifier('Taro'))
+      }
+    },
+    CallExpression(path) {
+      // wxs文件中的getRegExp转换为new RegExp
+      if (t.isIdentifier(path.node.callee, { name: 'getRegExp' })) {
+        const arg = path.node.arguments[0]
+        if (t.isStringLiteral(arg)) {
+          const regex = arg.extra?.raw as string
+          const regexWithoutQuotes = regex.replace(/^'(.*)'$/, '$1')
+          const newExpr = t.newExpression(t.identifier('RegExp'), [
+            t.stringLiteral(regexWithoutQuotes),
+            t.stringLiteral('g'),
+          ])
+          path.replaceWith(newExpr)
+        }
+      }
+    },
+  }
+
+  traverse(ast, vistor)
+
+  const code = generate(ast.program as any).code
+  return {
+    ...defaultResult,
+    ast,
+    code,
+  }
+}

--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -229,9 +229,9 @@ export const createWxmlVistor = (
             )
             path.remove()
           }
-          /*} else {
+          /* } else {
             throw codeFrameError(slotValue, 'slot 的值必须是一个字符串')
-          }*/
+          } */
         }
         const tagName = jsxName.node.name
         if (tagName === 'Slot') {
@@ -435,8 +435,15 @@ function getWXS (attrs: t.JSXAttribute[], path: NodePath<t.JSXElement>, imports:
     const ast = parseCode(script.value)
     traverse(ast, {
       CallExpression (path) {
+        // wxs标签中getRegExp转换为new RegExp
         if (t.isIdentifier(path.node.callee, { name: 'getRegExp' })) {
-          console.warn(codeFrameError(path.node, '请使用 JavaScript 标准正则表达式把这个 getRegExp 函数重构。'))
+          const arg = path.node.arguments[0]
+          if (t.isStringLiteral(arg)) {
+            const regex = arg.extra?.raw as string
+            const regexWithoutQuotes = regex.replace(/^'(.*)'$/, '$1')
+            const newExpr = t.newExpression(t.identifier('RegExp'), [t.stringLiteral(regexWithoutQuotes), t.stringLiteral('g')])
+            path.replaceWith(newExpr)
+          }
         }
       }
     })


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
微信小程序转taro时，wxs标签和wxs文件中getRegExp转换为new RegExp

**这个 PR 是什么类型?** (至少选择一个)
- [ ] 错误修复(Bugfix) issue: fix # 微信小程序转taro时，wxs标签和wxs文件中getRegExp转换为new RegExp

**这个 PR 涉及以下平台:**
- [ ] 微信小程序
