### PR TITLE
fix: 修复解构符...转换报错

### DIFF
--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
+import { parse as parseFile } from '@babel/parser'
 import traverse, { NodePath, Visitor } from '@babel/traverse'
 import * as t from '@babel/types'
 import {
   printLog,
   processTypeEnum
 } from '@tarojs/helper'
-import { parse as parseFile } from 'babylon'
 import { parse } from 'himalaya-wxml'
 import { camelCase, cloneDeep } from 'lodash'
 
@@ -785,6 +785,7 @@ function parseText (node: Text, tagName?: string) {
   return t.jSXExpressionContainer(buildTemplate(content))
 }
 
+// 匹配{{content}}
 const handlebarsRE = /\{\{((?:.|\n)+?)\}\}/g
 
 function singleQuote (s: string) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复解构符...转换报错
在babel6中解构符...对应的ast节点类型为SpreadProperty，在babel7中变更为SpreadElement，所以在代码转换成ast和变换后的ast转换成code的步骤中需要统一使用相同版本的babel，此处的修改是将代码转换时使用6.x的baylon更新为7.x的@babel/parser


**这个 PR 是什么类型?** (至少选择一个)
- [ ] 错误修复(Bugfix) issue: fix #

**这个 PR 涉及以下平台:**
- [ ] 微信小程序
