### PR TITLE
fix: 修复async/await会转换成生成器函数，保留async/await

### DIFF
--- a/packages/taro-transformer-wx/package.json
+++ b/packages/taro-transformer-wx/package.json
@@ -53,7 +53,6 @@
     "@babel/plugin-proposal-optional-chaining": "^7.21.0",
     "@babel/plugin-syntax-async-generators": "^7.8.4",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
-    "@babel/plugin-transform-async-to-generator": "^7.22.5",
     "@babel/plugin-transform-exponentiation-operator": "^7.22.5",
     "@babel/plugin-transform-flow-strip-types": "^7.22.5",
     "@babel/plugin-transform-react-jsx": "^7.14.5",

--- a/packages/taro-transformer-wx/src/index.ts
+++ b/packages/taro-transformer-wx/src/index.ts
@@ -8,7 +8,6 @@ import objectRestSpread from '@babel/plugin-proposal-object-rest-spread'
 import optionalChaining from '@babel/plugin-proposal-optional-chaining'
 import asyncGenerators from '@babel/plugin-syntax-async-generators'
 import dynamicImport from '@babel/plugin-syntax-dynamic-import'
-import asyncFunctions from '@babel/plugin-transform-async-to-generator'
 import exponentiationOperator from '@babel/plugin-transform-exponentiation-operator'
 import flowStrip from '@babel/plugin-transform-flow-strip-types'
 import jsxPlugin from '@babel/plugin-transform-react-jsx'
@@ -234,7 +233,6 @@ function parseCode (code: string) {
       classProperties,
       jsxPlugin,
       flowStrip,
-      asyncFunctions,
       exponentiationOperator,
       asyncGenerators,
       objectRestSpread,

--- a/packages/taroize/package.json
+++ b/packages/taroize/package.json
@@ -29,7 +29,6 @@
     "@babel/plugin-syntax-async-generators": "^7.8.4",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/plugin-syntax-flow": "^7.22.5",
-    "@babel/plugin-transform-async-to-generator": "^7.22.5",
     "@babel/plugin-transform-exponentiation-operator": "^7.22.5",
     "@babel/plugin-transform-flow-strip-types": "^7.22.5",
     "@babel/plugin-transform-react-jsx": "^7.14.5",

--- a/packages/taroize/src/utils.ts
+++ b/packages/taroize/src/utils.ts
@@ -7,7 +7,6 @@ import objectRestSpread from '@babel/plugin-proposal-object-rest-spread'
 import optionalChaining from '@babel/plugin-proposal-optional-chaining'
 import asyncGenerators from '@babel/plugin-syntax-async-generators'
 import dynamicImport from '@babel/plugin-syntax-dynamic-import'
-import asyncFunctions from '@babel/plugin-transform-async-to-generator'
 import exponentiationOperator from '@babel/plugin-transform-exponentiation-operator'
 import flowStrip from '@babel/plugin-transform-flow-strip-types'
 import jsxPlugin from '@babel/plugin-transform-react-jsx'
@@ -56,7 +55,6 @@ export function parseCode (code: string, scriptPath?: string) {
         classProperties,
         jsxPlugin,
         flowStrip,
-        asyncFunctions,
         exponentiationOperator,
         asyncGenerators,
         objectRestSpread,
@@ -74,7 +72,6 @@ export function parseCode (code: string, scriptPath?: string) {
       classProperties,
       jsxPlugin,
       flowStrip,
-      asyncFunctions,
       exponentiationOperator,
       asyncGenerators,
       objectRestSpread,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复async/await会转换成生成器函数，保留async/await
在之前的转换过程中，async/await会转换成生成器函数，如下
转化前：
![image](https://github.com/handsomeliuyang/taro/assets/110598219/f854fbbd-b96b-4af7-9f1e-9e0f2bbbc856)
转换后：
![image](https://github.com/handsomeliuyang/taro/assets/110598219/98e817c6-ba2b-4cbf-85a4-17edd63402f3)



**这个 PR 是什么类型?** (至少选择一个)
- [ ] 错误修复(Bugfix) issue: fix #

**这个 PR 涉及以下平台:**
- [ ] 微信小程序
