### PR TITLE
fix: 修复自定义组件文件名为index时的引用问题

### DIFF
--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -548,6 +548,7 @@ export default class Convertor {
     return fs.copySync(from, to, options)
   }
 
+  // 自定义组件，如果组件文件命名为index，引入时可省略index这一层，解析时需加上
   getComponentPath (component: string, extname: string) {
     if (fs.existsSync(component + extname)) return component + extname
     else return component + '/index' + extname
@@ -796,11 +797,11 @@ ${code}
       if (this.hadBeenBuiltComponents.has(component)) return
       this.hadBeenBuiltComponents.add(component)
 
-      const componentJSPath = component + this.fileTypes.SCRIPT
+      const componentJSPath = this.getComponentPath(component, this.fileTypes.SCRIPT)
       const componentDistJSPath = this.getDistFilePath(componentJSPath)
-      const componentConfigPath = component + this.fileTypes.CONFIG
-      const componentStylePath = component + this.fileTypes.STYLE
-      const componentTemplPath = component + this.fileTypes.TEMPL
+      const componentConfigPath = this.getComponentPath(component, this.fileTypes.CONFIG)
+      const componentStylePath = this.getComponentPath(component, this.fileTypes.STYLE)
+      const componentTemplPath = this.getComponentPath(component, this.fileTypes.TEMPL)
 
       try {
         const param: ITaroizeOptions = {}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
自定义组件中文件名为index.xxx，引入时路径可以只到文件夹，此时报js文件找不到
![image](https://github.com/handsomeliuyang/taro/assets/110598219/e9421361-3118-4e82-ba7a-b8fc8bc60aa6)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
