### PR TITLE
fix: 适配convert.config.json，对符合json内路径的文件，在其被导入时不做转换

### DIFF
--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -396,10 +396,9 @@ export default class Convertor {
       convertJSONPath = path.join(this.root, `convert.config${this.fileTypes.CONFIG}`)
     }
     if (fs.existsSync(convertJSONPath)){
-      let convertJSON:string[]
       try {
-        convertJSON= JSON.parse(String(fs.readFileSync(convertJSONPath)))
-        const externalJson = convertJSON['external']
+        const convertJSON= JSON.parse(String(fs.readFileSync(convertJSONPath)))
+        const externalJson = convertJSON.external
         const absolute_path:string[] = []
         for (const iRpath of externalJson){
           // 相对路径转为绝对路径

--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -399,7 +399,7 @@ export default class Convertor {
       let convertJSON:string[]
       try {
         convertJSON= JSON.parse(String(fs.readFileSync(convertJSONPath)))
-        const externalJson = convertJSON.external
+        const externalJson = convertJSON['external']
         const absolute_path:string[] = []
         for (const iRpath of externalJson){
           // 相对路径转为绝对路径


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
适配微信小程序根目录新增convert.config.json时，对key为external的value进行保存并转化为绝对路径，此路径匹配到的路径文件在被导入时将不会被转换


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
