### PR TITLE
fix: 修改媒体-富文本的insertImage换行不生效等问题，增加富文本的接口的可测试性

### DIFF
--- a/examples/mini-program-example/src/pages/api/media/image/index.tsx
+++ b/examples/mini-program-example/src/pages/api/media/image/index.tsx
@@ -103,7 +103,12 @@ export default class Index extends React.Component {
       },
       {
         id: 'previewImage',
-        func: (apiIndex) => {
+        inputData: {
+          current: '',
+          showmenu: false,
+          referrerPolicy: '',
+        },
+        func: (apiIndex, data) => {
           TestConsole.consoleTest('previewImage')
           Taro.chooseImage({
             count: 3,
@@ -113,9 +118,7 @@ export default class Index extends React.Component {
               TestConsole.consoleNormal('chooseImage success:', res)
               Taro.previewImage({
                 urls: res.tempFilePaths,
-                current: 'test/currentField',
-                showmenu: false,
-                referrerPolicy: 'origin',
+                ...data,
                 success: (res) => {
                   TestConsole.consoleSuccess.call(this, res, apiIndex)
                 },
@@ -386,7 +389,7 @@ export default class Index extends React.Component {
       },
     ],
   }
-  render() {
+  render () {
     const { list } = this.state
     return (
       <View className='api-page'>

--- a/examples/mini-program-example/src/pages/api/media/richText/index.tsx
+++ b/examples/mini-program-example/src/pages/api/media/richText/index.tsx
@@ -45,9 +45,6 @@ export default class Index extends React.Component {
                 TestConsole.consoleComplete.call(this, res, apiIndex)
               },
             })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
-            })
         },
       },
       {
@@ -65,9 +62,6 @@ export default class Index extends React.Component {
               complete: (res) => {
                 TestConsole.consoleComplete.call(this, res, apiIndex)
               },
-            })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
             })
         },
       },
@@ -91,21 +85,17 @@ export default class Index extends React.Component {
         id: 'EditorContext_getContents',
         func: (apiIndex) => {
           TestConsole.consoleTest('EditorContext_getContents')
-          editorContext
-            .getContents({
-              success: (res) => {
-                TestConsole.consoleSuccess.call(this, res, apiIndex)
-              },
-              fail: (res) => {
-                TestConsole.consoleFail.call(this, res, apiIndex)
-              },
-              complete: (res) => {
-                TestConsole.consoleComplete.call(this, res, apiIndex)
-              },
-            })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
-            })
+          editorContext.getContents({
+            success: (res) => {
+              TestConsole.consoleSuccess.call(this, res, apiIndex)
+            },
+            fail: (res) => {
+              TestConsole.consoleFail.call(this, res, apiIndex)
+            },
+            complete: (res) => {
+              TestConsole.consoleComplete.call(this, res, apiIndex)
+            },
+          })
         },
       },
       {
@@ -124,24 +114,24 @@ export default class Index extends React.Component {
                 TestConsole.consoleComplete.call(this, res, apiIndex)
               },
             })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
-            })
         },
       },
       {
         id: 'EditorContext_insertImage',
-        func: (apiIndex) => {
+        inputData: {
+          src: 'https://user-images.githubusercontent.com/3369400/133268513-5bfe2f93-4402-42c9-a403-81c9e86934b6.jpeg',
+          nowrap: false,
+          alt: 'hello,beautiful world',
+          data: '',
+          extClass: 'test_image',
+          height: '100',
+          width: '100',
+        },
+        func: (apiIndex, data) => {
           TestConsole.consoleTest('EditorContext_insertImage')
           editorContext
             .insertImage({
-              src: '',
-              nowrap: true,
-              alt: 'hello,beautiful world',
-              data: '',
-              extClass: 'test_image',
-              height: '100',
-              width: '100',
+              ...data,
               success: (res) => {
                 TestConsole.consoleSuccess.call(this, res, apiIndex)
               },
@@ -151,19 +141,19 @@ export default class Index extends React.Component {
               complete: (res) => {
                 TestConsole.consoleComplete.call(this, res, apiIndex)
               },
-            })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
             })
         },
       },
       {
         id: 'EditorContext_insertText',
-        func: (apiIndex) => {
+        inputData: {
+          text: 'developer conference',
+        },
+        func: (apiIndex, data) => {
           TestConsole.consoleTest('EditorContext_insertText')
           editorContext
             .insertText({
-              text: 'developer conference',
+              ...data,
               success: (res) => {
                 TestConsole.consoleSuccess.call(this, res, apiIndex)
               },
@@ -173,9 +163,6 @@ export default class Index extends React.Component {
               complete: (res) => {
                 TestConsole.consoleComplete.call(this, res, apiIndex)
               },
-            })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
             })
         },
       },
@@ -195,9 +182,6 @@ export default class Index extends React.Component {
                 TestConsole.consoleComplete.call(this, res, apiIndex)
               },
             })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
-            })
         },
       },
       {
@@ -216,9 +200,6 @@ export default class Index extends React.Component {
                 TestConsole.consoleComplete.call(this, res, apiIndex)
               },
             })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
-            })
         },
       },
       {
@@ -231,12 +212,15 @@ export default class Index extends React.Component {
       },
       {
         id: 'EditorContext_setContents',
-        func: (apiIndex) => {
+        inputData: {
+          delta: '',
+          html: 'test_html',
+        },
+        func: (apiIndex, data) => {
           TestConsole.consoleTest('EditorContext_setContents')
           editorContext
             .setContents({
-              delta: 'test_contents',
-              html: 'test_html',
+              ...data,
               success: (res) => {
                 TestConsole.consoleSuccess.call(this, res, apiIndex)
               },
@@ -246,9 +230,6 @@ export default class Index extends React.Component {
               complete: (res) => {
                 TestConsole.consoleComplete.call(this, res, apiIndex)
               },
-            })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
             })
         },
       },
@@ -268,9 +249,6 @@ export default class Index extends React.Component {
                 TestConsole.consoleComplete.call(this, res, apiIndex)
               },
             })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
-            })
         },
       },
       {
@@ -289,14 +267,11 @@ export default class Index extends React.Component {
                 TestConsole.consoleComplete.call(this, res, apiIndex)
               },
             })
-            .then((res) => {
-              TestConsole.consoleReturn.call(this, res, apiIndex)
-            })
         },
       },
     ],
   }
-  render() {
+  render () {
     const { list } = this.state
     return (
       <View className='api-page'>

--- a/packages/taro-mpharmony/src/api/media/EditorContext.ts
+++ b/packages/taro-mpharmony/src/api/media/EditorContext.ts
@@ -28,23 +28,23 @@ export class EditorContext implements Taro.EditorContext {
       const selection = this.activeEditor()?.selection
       if (selection) {
         const selectionText = selection.getContent({ format: 'text' })
-        option?.success?.({ errMsg: '', text: selectionText })
+        option?.success?.({ errMsg: 'ok', text: selectionText })
       }
     } catch (e) {
       option?.fail?.({ errMsg: `${e}` })
     } finally {
-      option?.complete?.({ errMsg: `` })
+      option?.complete?.({ errMsg: `ok` })
     }
   }
 
   clear (option?: Taro.EditorContext.ClearOption | undefined): void {
     try {
       this.activeEditor()?.setContent('')
-      option?.success?.({ errMsg: `` })
+      option?.success?.({ errMsg: `ok` })
     } catch (e) {
       option?.fail?.({ errMsg: `${e}` })
     } finally {
-      option?.complete?.({ errMsg: `` })
+      option?.complete?.({ errMsg: `ok` })
     }
   }
 
@@ -162,7 +162,7 @@ export class EditorContext implements Taro.EditorContext {
       const editor = this.activeEditor()
       if (editor) {
         option?.success?.({
-          errMsg: '',
+          errMsg: 'ok',
           html: editor.getContent({ format: 'html' }),
           text: editor.getContent({ format: 'text' }),
           delta: editor.getContent({ format: 'tree' }),
@@ -171,17 +171,15 @@ export class EditorContext implements Taro.EditorContext {
     } catch (e) {
       option?.fail?.({ errMsg: `${e}` })
     } finally {
-      option?.complete?.({ errMsg: `` })
+      option?.complete?.({ errMsg: `ok` })
     }
-
-    option?.complete?.({ errMsg: `` })
   }
 
   insertDivider (option?: Taro.EditorContext.InsertDividerOption | undefined): void {
     try {
       option?.fail?.({ errMsg: 'not support EditorContext.insertDivider api.' })
     } finally {
-      option?.complete?.({ errMsg: '' })
+      option?.complete?.({ errMsg: 'ok' })
     }
   }
 
@@ -198,13 +196,13 @@ export class EditorContext implements Taro.EditorContext {
       )
       const nowrap = option.nowrap || false
       if (nowrap === false) {
-        this.activeEditor()?.insertContent(`<br/>`)
+        this.activeEditor()?.insertContent(`<br/><br/>`)
       }
-      option?.success?.({ errMsg: `` })
+      option?.success?.({ errMsg: `ok` })
     } catch (e) {
       option?.fail?.({ errMsg: `${e}` })
     } finally {
-      option?.complete?.({ errMsg: `` })
+      option?.complete?.({ errMsg: `ok` })
     }
   }
 
@@ -214,11 +212,11 @@ export class EditorContext implements Taro.EditorContext {
       if (text.length > 0) {
         this.activeEditor()?.insertContent(text)
       }
-      option?.success?.({ errMsg: `` })
+      option?.success?.({ errMsg: `ok` })
     } catch (e) {
       option?.fail?.({ errMsg: `${e}` })
     } finally {
-      option?.complete?.({ errMsg: `` })
+      option?.complete?.({ errMsg: `ok` })
     }
   }
 
@@ -226,11 +224,11 @@ export class EditorContext implements Taro.EditorContext {
     try {
       // https://www.tiny.cloud/docs/tinymce/6/editor-command-identifiers/#supported-browser-native-commands
       this.activeEditor()?.execCommand('RemoveFormat')
-      option?.success?.({ errMsg: `` })
+      option?.success?.({ errMsg: `ok` })
     } catch (e) {
       option?.fail?.({ errMsg: `${e}` })
     } finally {
-      option?.complete?.({ errMsg: `` })
+      option?.complete?.({ errMsg: `ok` })
     }
   }
 
@@ -253,33 +251,33 @@ export class EditorContext implements Taro.EditorContext {
         }
       }
 
-      option?.success?.({ errMsg: `` })
+      option?.success?.({ errMsg: `ok` })
     } catch (e) {
       option?.fail?.({ errMsg: `${e}` })
     } finally {
-      option?.complete?.({ errMsg: `` })
+      option?.complete?.({ errMsg: `ok` })
     }
   }
 
   redo (option?: Taro.EditorContext.RedoOption | undefined): void {
     try {
       this.activeEditor()?.undoManager.redo()
-      option?.success?.({ errMsg: `` })
+      option?.success?.({ errMsg: `ok` })
     } catch (e) {
       option?.fail?.({ errMsg: `${e}` })
     } finally {
-      option?.complete?.({ errMsg: `` })
+      option?.complete?.({ errMsg: `ok` })
     }
   }
 
   undo (option?: Taro.EditorContext.UndoOption | undefined): void {
     try {
       this.activeEditor()?.undoManager.undo()
-      option?.success?.({ errMsg: `` })
+      option?.success?.({ errMsg: `ok` })
     } catch (e) {
       option?.fail?.({ errMsg: `${e}` })
     } finally {
-      option?.complete?.({ errMsg: `` })
+      option?.complete?.({ errMsg: `ok` })
     }
   }
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
fix: 修改媒体-富文本的insertImage换行不生效等问题，增加富文本接口的可测试性


**这个 PR 是什么类型?** (至少选择一个)
fix
- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**
鸿蒙（harmony）
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
