### PR TITLE
fix: 修改媒体-富文本的removeFormat无法清除文本样式的问题

### DIFF
--- a/examples/mini-program-example/src/pages/api/media/video/index.tsx
+++ b/examples/mini-program-example/src/pages/api/media/video/index.tsx
@@ -160,14 +160,6 @@ export default class Index extends React.Component {
         },
       },
       {
-        id: 'createVideoContext',
-        func: (apiIndex) => {
-          TestConsole.consoleTest('createVideoContext')
-          videoContext = Taro.createVideoContext('myVideo')
-          TestConsole.consoleNormal('createVideoContext ', videoContext)
-        },
-      },
-      {
         id: 'compressVideo_暂不支持',
         func: null,
       },
@@ -236,6 +228,14 @@ export default class Index extends React.Component {
           }).then((res) => {
             TestConsole.consoleReturn.call(this, res, apiIndex)
           })
+        },
+      },
+      {
+        id: 'createVideoContext',
+        func: (apiIndex) => {
+          TestConsole.consoleTest('createVideoContext')
+          videoContext = Taro.createVideoContext('myVideo')
+          TestConsole.consoleNormal('createVideoContext ', videoContext)
         },
       },
       {
@@ -322,6 +322,11 @@ export default class Index extends React.Component {
           videoContext.requestFullScreen({
             direction: 0,
           })
+          setTimeout(() => {
+            videoContext.exitFullScreen()
+            TestConsole.consoleNormal('exitFullScreen')
+          }, 20000)
+
           TestConsole.consoleNormal('requestFullScreen')
         },
       },
@@ -362,7 +367,7 @@ export default class Index extends React.Component {
       },
     ],
   }
-  render() {
+  render () {
     const { list } = this.state
     return (
       <View className='api-page'>

--- a/packages/taro-components/src/components/video/video.tsx
+++ b/packages/taro-components/src/components/video/video.tsx
@@ -451,7 +451,7 @@ export class Video implements ComponentInterface {
   }
 
   @Method()
-  async getHlsObject() {
+  async getHlsObject () {
     // Note: H5 端专属方法，获取 HLS 实例 fix #11894
     return this.hls
   }
@@ -537,6 +537,7 @@ export class Video implements ComponentInterface {
 
   toggleFullScreen = (isFullScreen = !this.isFullScreen) => {
     this.isFullScreen = isFullScreen // this.videoRef?.['webkitDisplayingFullscreen']
+    console.log('1111111:' + this.isFullScreen)
     this.controlsRef.toggleVisibility(true)
     this.fullScreenTimestamp = new Date().getTime()
     this.onFullScreenChange.emit({

--- a/packages/taro-mpharmony/src/api/media/EditorContext.ts
+++ b/packages/taro-mpharmony/src/api/media/EditorContext.ts
@@ -223,7 +223,13 @@ export class EditorContext implements Taro.EditorContext {
   removeFormat (option?: Taro.EditorContext.RemoveFormatOption | undefined): void {
     try {
       // https://www.tiny.cloud/docs/tinymce/6/editor-command-identifiers/#supported-browser-native-commands
+
+      this.activeEditor()?.formatter.remove('alignleft')
+      this.activeEditor()?.formatter.remove('aligncenter')
+      this.activeEditor()?.formatter.remove('alignright')
+      this.activeEditor()?.formatter.remove('alignjustify')
       this.activeEditor()?.execCommand('RemoveFormat')
+
       option?.success?.({ errMsg: `ok` })
     } catch (e) {
       option?.fail?.({ errMsg: `${e}` })


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修改媒体-富文本的removeFormat无法清除文本样式的问题


**这个 PR 是什么类型?** (至少选择一个)
fix
- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**
鸿蒙（harmony
- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
