### PR TITLE
fix: 修复复制三方库时因为符号链接造成的一些问题

### DIFF
--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -714,9 +714,18 @@ ${code}
   // 调用copyFileToTaro实现拷贝对应的三方库到node_modules
   generateNodeModule (modulePath: string) {
     const parts = modulePath.split('/')
-    const moduleConvertPath = path.resolve(this.convertRoot, 'node_modules', parts[0])
+    let moduleConvertPath = path.resolve(this.convertRoot, 'node_modules', parts[0])
     if (!fs.existsSync(moduleConvertPath)) {
-      const moduleRootPath = path.resolve(this.root, 'node_modules', parts[0])
+      let moduleRootPath = path.resolve(this.root, 'node_modules', parts[0])
+      // 如果是pnpm下载的三方库，node_modules下的依赖包为快捷方式
+      while (fs.readdirSync(moduleRootPath).length < 2) {
+        const folders = fs.readdirSync(moduleRootPath)
+        moduleRootPath = path.join(moduleRootPath, folders[0])
+        moduleConvertPath = path.join(moduleConvertPath, folders[0])
+      }
+      if (fs.lstatSync(moduleRootPath).isSymbolicLink()) {
+        moduleRootPath = fs.readlinkSync(moduleRootPath)
+      }
       copyFileToTaro(moduleRootPath, moduleConvertPath)
     }
   }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复复制三方库时因为符号链接造成的一些问题
pnpm install安装依赖包，node_modules下的依赖包为快捷方式（符号链接），依赖包真正的位置在node_modules/.pnpm下
调用fs.readlinkSync读取链接地址



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
