### PR TITLE
fix: 删去三方库复制时某些场景下pnpm包快捷方式地址的获取

### DIFF
--- a/packages/taro-cli-convertor/src/util/index.ts
+++ b/packages/taro-cli-convertor/src/util/index.ts
@@ -163,14 +163,9 @@ export function handleThirdPartyLib (filePath: string, nodePath: string[], root:
     if (fs.existsSync(npmModulePath)) {
       isThirdPartyLibExist = true
       // 转换后的三方库放在node_modules中
-      let moduleConvertPath = path.resolve(convertRoot, NODE_MODULES, parts[0])
+      const moduleConvertPath = path.resolve(convertRoot, NODE_MODULES, parts[0])
       if (!fs.existsSync(moduleConvertPath)) {
         // 如果是pnpm下载的三方库，node_modules下的依赖包为快捷方式
-        while (fs.readdirSync(npmModulePath).length < 2) {
-          const folders = fs.readdirSync(npmModulePath)
-          npmModulePath = path.join(npmModulePath, folders[0])
-          moduleConvertPath = path.join(moduleConvertPath, folders[0])
-        }
         if (fs.lstatSync(npmModulePath).isSymbolicLink()) {
           npmModulePath = fs.readlinkSync(npmModulePath)
         }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
删去三方库复制时某些场景下pnpm包快捷方式地址的获取


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
