### PR TITLE
fix: 修复wxss文件注释中引用自身导致的转换死循环

### DIFF
--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -29,6 +29,7 @@ import {
   copyFileToTaro,
   getMatchUnconvertDir,
   getPkgVersion,
+  getWxssImports,
   handleThirdPartyLib,
   handleUnconvertDir,
   incrementId,
@@ -99,13 +100,13 @@ interface IConvertConfig {
 }
 
 function processStyleImports (content: string, processFn: (a: string, b: string) => string) {
-  const style: string[] = []
-  const imports: string[] = []
+  // 获取css中的引用样式文件路径集合
+  const imports: string[] = getWxssImports(content)
+
+  // 将引用的样式文件路径转换为相对路径，后缀名转换为.scss
   const styleReg = new RegExp('.wxss')
   content = content.replace(CSS_IMPORT_REG, (m, _$1, $2) => {
     if (styleReg.test($2)) {
-      style.push(m)
-      imports.push($2)
       if (processFn) {
         return processFn(m, $2)
       }
@@ -116,9 +117,9 @@ function processStyleImports (content: string, processFn: (a: string, b: string)
     }
     return m
   })
+
   return {
     content,
-    style,
     imports,
   }
 }

--- a/packages/taro-cli-convertor/src/util/index.ts
+++ b/packages/taro-cli-convertor/src/util/index.ts
@@ -1,5 +1,6 @@
 import {
   chalk,
+  CSS_IMPORT_REG,
   fs,
   printLog,
   processTypeEnum,
@@ -253,4 +254,23 @@ export function transRelToAbsPath (baseFilePath: string, fileRelativePaths: stri
     absolutePath.push(path.resolve(baseFilePath, '..', fileRelativePath))
   }
   return absolutePath
+}
+
+// 获取wxss中引用文件的相对路径集合
+export function getWxssImports (content: string) {
+  if (content == null) {
+    return []
+  }
+  // 匹配 /* ... */ 形式的注释
+  const regex = /\/\*([\s\S]*?)\*\//g
+  // 去掉css中的注释
+  const contentWithoutComment = content.replace(regex, '')
+
+  let match
+  const imports: string[] = []
+  const cssImportReg = new RegExp(CSS_IMPORT_REG)
+  while ((match = cssImportReg.exec(contentWithoutComment)) !== null) {
+    imports.push(match[2])
+  }
+  return imports
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
问题：
修复wxss文件注释中引用自身导致的转换死循环
修复方案：
转换wxss文件时，不考虑注释中的引用


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
