### PR TITLE
feat: 支持配置不转换的页面

### DIFF
--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -719,6 +719,14 @@ ${code}
   traversePages () {
     this.pages.forEach((page) => {
       const pagePath = this.isTsProject ? path.join(this.miniprogramRoot, page) : path.join(this.root, page)
+
+      // 处理不转换的页面，可在convert.config.json中external字段配置
+      const matchUnconvertDir: string | null = getMatchUnconvertDir(pagePath, this.convertConfig?.external)
+      if (matchUnconvertDir !== null) {
+        handleUnconvertDir(matchUnconvertDir, this.root, this.convertRoot)
+        return
+      }
+
       const pageJSPath = pagePath + this.fileTypes.SCRIPT
       const pageDistJSPath = this.getDistFilePath(pageJSPath)
       const pageConfigPath = pagePath + this.fileTypes.CONFIG

--- a/packages/taro-cli-convertor/src/util/index.ts
+++ b/packages/taro-cli-convertor/src/util/index.ts
@@ -197,14 +197,15 @@ export function getMatchUnconvertDir (importPath: string, externalPaths: string[
   }
   // 支持用户在convert.config.json中配置不转换的目录
   for (let externalPath of externalPaths) {
-    externalPath = normalizePath(externalPath)
+    externalPath = normalizePath(externalPath).replace('*', '.*')
     const reg = new RegExp(externalPath)
     const match = reg.exec(normalizePath(importPath))
     // external字段配置如 1：../demo 2：../demo/* 3：../demo/*/demo
     if (match) {
       // 处理../demo/*
       if (externalPath.length >= 2 && externalPath.endsWith('*')) {
-        return externalPath.slice(0, externalPath.length - 2)
+        // 去掉结尾的".*"
+        return externalPath.slice(0, externalPath.length - 3)
       }
       return match[0]
     }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
支持配置不转换的页面
背景：
支持配置不转换的目录有两种
1、文件中引用的文件目录
2、页面


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
