### PR TITLE
fix: template模板转换引入装饰器@withWeapp

### DIFF
--- a/packages/taroize/src/template.ts
+++ b/packages/taroize/src/template.ts
@@ -96,6 +96,12 @@ export function parseTemplate (path: NodePath<t.JSXElement>, dirPath: string) {
       t.classBody([render]),
       []
     )
+    // 添加withWeapp装饰器
+    classDecl.decorators = [t.decorator(
+      t.callExpression(
+        t.identifier('withWeapp'), [t.objectExpression([])]
+      )
+    )]
     path.remove()
     return {
       name: className,

--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -258,18 +258,16 @@ export const createWxmlVistor = (
             const taroComponentsImport = buildImportStatement('@tarojs/components', [...usedComponents])
             const taroImport = buildImportStatement('@tarojs/taro', [], 'Taro')
             const reactImport = buildImportStatement('react', [], 'React')
-            // const withWeappImport = buildImportStatement(
-            //   '@tarojs/with-weapp',
-            //   [],
-            //   'withWeapp'
-            // )
+            // 引入 @tarojs/with-weapp
+            const withWeappImport = buildImportStatement('@tarojs/with-weapp',[],'withWeapp')
             const ast = t.file(t.program([]))
             ast.program.body.unshift(
               taroComponentsImport,
               reactImport,
               taroImport,
-              // withWeappImport,
-              t.exportDefaultDeclaration(classDecl)
+              withWeappImport,
+              classDecl,
+              t.exportDefaultDeclaration(t.identifier(name))
             )
             const usedTemplate = new Set<string>()
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
当前template转换后，会引入一些原生不支持的接口；
在template模板转换时引入装饰器@withWeapp，以适配这些接口，转换结果形如下图
![image](https://github.com/handsomeliuyang/taro/assets/71969189/16f29320-d905-4f8c-9ce9-5f9f5483cf85)


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
