### PR TITLE
fix: 修复以/开头文件导入时找不到文件

### DIFF
--- a/packages/taro-cli-convertor/src/util/index.ts
+++ b/packages/taro-cli-convertor/src/util/index.ts
@@ -8,7 +8,7 @@ import {
   REG_SCRIPT,
   REG_TYPESCRIPT,
   resolveScriptPath,
-} from '@tarojs/helper'
+  SCRIPT_EXT } from '@tarojs/helper'
 import * as path from 'path'
 
 import type * as t from '@babel/types'
@@ -23,32 +23,51 @@ export function getPkgVersion (): string {
   return require(path.join(getRootPath(), 'package.json')).version
 }
 
-function getRelativePath (rootPath: string, sourceFilePath: string, oriPath: string) {
+// 文件存在或添加后缀.js、.jsx、.ts、.tsx存在则返回文件路径，否则返回null
+function revertScriptPath (absolutePath: string, SCRIPT_EXT: string[]) {
+  for (const item of SCRIPT_EXT){
+    if (fs.existsSync(absolutePath)){
+      return absolutePath
+    } else if (fs.existsSync(`${absolutePath}${item}`)){
+      return `${absolutePath}${item}`
+    }
+  }
+  return null
+}
+
+function getRelativePath (_rootPath: string, sourceFilePath: string, oriPath: string) {
   // 处理以/开头的绝对路径，比如 /a/b
   if (path.isAbsolute(oriPath)) {
     if (oriPath.indexOf('/') !== 0) {
+      return oriPath
+    }
+    const absolutePath = revertScriptPath(path.resolve(sourceFilePath, '..' + oriPath), SCRIPT_EXT)
+    if (absolutePath == null) {
       return ''
     }
-    const vpath = path.resolve(rootPath, oriPath.substr(1))
-    if (!fs.existsSync(vpath)) {
-      return ''
-    }
-    let relativePath = path.relative(path.dirname(sourceFilePath), vpath)
+
+    let relativePath = path.relative(path.dirname(sourceFilePath), absolutePath)
     relativePath = promoteRelativePath(relativePath)
     if (relativePath.indexOf('.') !== 0) {
-      return './' + relativePath
+      return `./${relativePath}`
     }
     return relativePath
   }
   // 处理非正常路径，比如 a/b
   if (oriPath.indexOf('.') !== 0) {
-    const vpath = path.resolve(sourceFilePath, '..', oriPath)
-    if (fs.existsSync(vpath)) {
-      return `./${oriPath}`
-    } else if (fs.existsSync(`${vpath}.js`)) {
-      // 微信小程序中js文件的引用可不加后缀，需考虑
-      return `./${oriPath}.js`
+    const absolutePath = revertScriptPath(path.resolve(sourceFilePath, '..', oriPath), SCRIPT_EXT)
+
+    // 可能为三方库
+    if (absolutePath == null) {
+      return oriPath
     }
+    
+    let relativePath = path.relative(path.dirname(sourceFilePath), absolutePath)
+    relativePath = promoteRelativePath(relativePath)
+    if (relativePath.indexOf('.') !== 0) {
+      return `./${relativePath}`
+    }
+    return relativePath
   }
   return oriPath
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复在微信小程序使用/开头路径导入文件时转换找不到的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
