### PR TITLE
fix: 自定义事件绑定（catch:xxx）转换去除this.privateStopNoop包裹

### DIFF
--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -861,15 +861,7 @@ function parseAttribute (attr: Attribute) {
       jsxValue = t.jSXExpressionContainer(t.memberExpression(t.thisExpression(), t.identifier('privateStopNoop')))
       globals.hasCatchTrue = true
     } else if (t.isStringLiteral(jsxValue)) {
-      jsxValue = t.jSXExpressionContainer(
-        t.callExpression(
-          t.memberExpression(
-            t.memberExpression(t.thisExpression(), t.identifier('privateStopNoop')),
-            t.identifier('bind')
-          ),
-          [t.thisExpression(), t.memberExpression(t.thisExpression(), t.identifier(jsxValue.value))]
-        )
-      )
+      jsxValue = t.jSXExpressionContainer(t.memberExpression(t.thisExpression(), t.identifier(jsxValue.value)))
     }
   }
   return t.jSXAttribute(t.jSXIdentifier(jsxKey), jsxValue)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
对于catch形式的自定义事件绑定，转换后会用this.privateStopNoop.bind（）进行包裹，其中调用了event接口e.stopPropagation() 。转换后的语句（ this.privateStopNoop.bind（this, this.xxx）），参数中的this不指向event，不支持e.stopPropagation() 接口

因此去掉this.privateStopNoop包裹


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
