### PR TITLE
fix: 当设置图片mode=""时，转换改为默认值

### DIFF
--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -163,6 +163,11 @@ export const createWxmlVistor = (
       }
     }
 
+    // 当设置图片mode="",则改为默认值(且taro不支持mode空值)
+    if (name.name === 'mode' && path.node.value === null) {
+      path.set('value', t.stringLiteral('scaleToFill'))
+    }
+
     // 当设置 style 属性但未赋值则删除该属性
     if (name.name === 'style' && !path.node.value) {
       path.remove()


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
把mode=""改成了mode="scaleToFill"(微信小程序的默认值)。由于mode=""被ast处理后重新转为代码会变成mode，并且mode=""在taro内表现与微信小程序内不同，所以改为默认值。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
