### PR TITLE
feat: 支持commonjs和es的导入导出混用

### DIFF
--- a/packages/taro-transformer-wx/src/index.ts
+++ b/packages/taro-transformer-wx/src/index.ts
@@ -13,6 +13,7 @@ import flowStrip from '@babel/plugin-transform-flow-strip-types'
 import jsxPlugin from '@babel/plugin-transform-react-jsx'
 import traverse, { Binding, NodePath } from '@babel/traverse'
 import * as t from '@babel/types'
+import babel_plugin_transform_commonjs from 'babel-plugin-transform-commonjs'
 // import * as template from '@babel/template'
 // const template = require('babel-template')
 import { prettyPrint } from 'html'
@@ -227,6 +228,7 @@ function parseCode(code: string) {
         [decorators, { legacy: true }],
         dynamicImport,
         optionalChaining,
+        babel_plugin_transform_commonjs,
       ],
     }) as { ast: t.File }
   ).ast

--- a/packages/taroize/package.json
+++ b/packages/taroize/package.json
@@ -40,6 +40,7 @@
     "@babel/types": "^7.21.4",
     "babel-core": "^6.26.3",
     "babel-generator": "^6.26.1",
+    "babel-plugin-transform-commonjs": "^1.1.6",
     "babel-template": "^6.26.0",
     "babel-traverse": "^6.26.0",
     "babel-types": "^6.26.0",

--- a/packages/taroize/src/utils.ts
+++ b/packages/taroize/src/utils.ts
@@ -14,6 +14,7 @@ import presetTypescript from '@babel/preset-typescript'
 import { default as template } from '@babel/template'
 import { NodePath } from '@babel/traverse'
 import * as t from '@babel/types'
+import babel_plugin_transform_commonjs from 'babel-plugin-transform-commonjs'
 import { camelCase, capitalize } from 'lodash'
 
 export function isAliasThis (p: NodePath<t.Node>, name: string) {
@@ -62,6 +63,7 @@ export function parseCode (code: string, scriptPath?: string) {
           [decorators, { legacy: true }],
           dynamicImport,
           optionalChaining,
+          babel_plugin_transform_commonjs,
         ],
       }) as { ast: t.File }
     ).ast
@@ -81,6 +83,7 @@ export function parseCode (code: string, scriptPath?: string) {
         [decorators, { legacy: true }],
         dynamicImport,
         optionalChaining,
+        babel_plugin_transform_commonjs,
       ],
     }) as { ast: t.File }
   ).ast


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
将commonjs的导入导出转换为es6的导入导出，支持commonjs和es的导入导出混用


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
