### PR TITLE
fix:修改api media中下video中的compressVideo按钮禁用问题

### DIFF
--- a/examples/mini-program-example/src/pages/api/media/video/index.tsx
+++ b/examples/mini-program-example/src/pages/api/media/video/index.tsx
@@ -161,7 +161,45 @@ export default class Index extends React.Component {
       },
       {
         id: 'compressVideo_暂不支持',
-        func: null,
+        // func: null,
+        func: (apiIndex) => {
+          TestConsole.consoleTest('compressVideo')
+          Taro.chooseVideo({
+            sourceType: ['album', 'camera'],
+            maxDuration: 60,
+            camera: 'back',
+            compressed:false,
+            success: (res) => {
+              
+              Taro.compressVideo({
+                src: res.tempFilePath,
+                quality:'high',
+                bitrate:1032,
+                fps:24,
+                resolution:0.5,
+                success: (res) => {
+                  TestConsole.consoleSuccess.call(this, res, apiIndex)
+                },
+                fail: (res) => {
+                  TestConsole.consoleFail.call(this, res, apiIndex)
+                },
+                complete: (res) => {
+                  TestConsole.consoleComplete.call(this, res, apiIndex)
+                },
+              }).then((res) => {
+                TestConsole.consoleReturn.call(this, res, apiIndex)
+              })
+            },
+            fail: (err) => {
+              TestConsole.consoleNormal('chooseVideo fail:', err)
+            },
+            complete: (com) => {
+              TestConsole.consoleNormal('chooseVideo complete', com)
+            },
+          }).then((ret) => {
+            TestConsole.consoleNormal('chooseVideo return', ret)
+          })
+        },
       },
       {
         id: 'chooseVideo_album',


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

fix:修改media api的video中的compressVideo按钮禁用问题

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 鸿蒙（harmony）
