### PR TITLE
fix: 导入导出commonjs转es6，代码回退

### DIFF
--- a/packages/taro-transformer-wx/src/index.ts
+++ b/packages/taro-transformer-wx/src/index.ts
@@ -12,7 +12,6 @@ import flowStrip from '@babel/plugin-transform-flow-strip-types'
 import jsxPlugin from '@babel/plugin-transform-react-jsx'
 import traverse, { Binding, NodePath } from '@babel/traverse'
 import * as t from '@babel/types'
-import babel_plugin_transform_commonjs from 'babel-plugin-transform-commonjs'
 // import * as template from '@babel/template'
 // const template = require('babel-template')
 import { prettyPrint } from 'html'
@@ -226,68 +225,9 @@ function parseCode(code: string) {
         objectRestSpread,
         [decorators, { legacy: true }],
         dynamicImport,
-        babel_plugin_transform_commonjs,
       ],
     }) as { ast: t.File }
   ).ast
-}
-
-// 删除commonjs转es6 加入的导出适配语句，包括var module = {exports: {},}、var exports = module.exports、export default module.exports
-function removeEs6AdapterStat(ast) {
-  traverse(ast, {
-    VariableDeclaration(path) {
-      const variableDeclarator = path.node.declarations[0]
-      if (t.isVariableDeclarator(variableDeclarator)) {
-        // 去除commonjs转es6生成的var module = {exports: {},}
-        if (
-          t.isIdentifier(variableDeclarator.id) &&
-          variableDeclarator.id.name === 'module' &&
-          t.isObjectExpression(variableDeclarator.init)
-        ) {
-          const init: t.ObjectExpression = variableDeclarator.init
-          if (
-            init.properties &&
-            init.properties.length > 0 &&
-            t.isObjectProperty(init.properties[0]) &&
-            t.isIdentifier(init.properties[0].key) &&
-            init.properties[0].key.name === 'exports'
-          ) {
-            path.remove()
-          }
-        }
-        // 去除commonjs转es6生成的var exports = module.exports
-        if (
-          t.isIdentifier(variableDeclarator.id) &&
-          variableDeclarator.id.name === 'exports' &&
-          t.isMemberExpression(variableDeclarator.init)
-        ) {
-          const init: t.MemberExpression = variableDeclarator.init
-          if (
-            t.isIdentifier(init.object) &&
-            init.object.name === 'module' &&
-            t.isIdentifier(init.property) &&
-            init.property.name === 'exports'
-          ) {
-            path.remove()
-          }
-        }
-      }
-    },
-    ExportDefaultDeclaration(path) {
-      const declaration = path.node.declaration
-      // 去除commonjs转es6生成的export default module.exports
-      if (t.isMemberExpression(declaration)) {
-        if (
-          t.isIdentifier(declaration.object) &&
-          declaration.object.name === 'module' &&
-          t.isIdentifier(declaration.property) &&
-          declaration.property.name === 'exports'
-        ) {
-          path.remove()
-        }
-      }
-    },
-  })
 }
 
 export default function transform(options: TransformOptions): TransformResult {
@@ -353,38 +293,6 @@ export default function transform(options: TransformOptions): TransformResult {
   //     }
   //   }
   // })
-
-  traverse(ast, {
-    AssignmentExpression(path) {
-      const left = path.get('left')
-      const right = path.get('right')
-
-      // 判断是否为module.exports = {}的格式
-      if (
-        t.isMemberExpression(left) &&
-        t.isIdentifier((left.get('object') as any).node, { name: 'module' }) &&
-        t.isIdentifier((left.get('property') as any).node, { name: 'exports' }) &&
-        t.isObjectExpression(right)
-      ) {
-        // 删除commonjs转es6 加入的导出适配语句，包括var module = {exports: {},}、var exports = module.exports、export default module.exports
-        removeEs6AdapterStat(ast)
-
-        // 将module.exports = {} 转为 export {}
-        const properties = right.get('properties') as any
-        if (properties.length > 0) {
-          const exportSpecifiers = properties.map((property) => {
-            if (t.isIdentifier(property.get('key'))) {
-              const name = property.get('key').node.name
-              return t.exportSpecifier(t.identifier(name), t.identifier(name))
-            }
-          })
-
-          const exportDeclaration = t.exportNamedDeclaration(null, exportSpecifiers)
-          path.parentPath.replaceWith(exportDeclaration)
-        }
-      }
-    },
-  })
 
   if (options.isNormal) {
     if (options.isTyped) {

--- a/packages/taroize/package.json
+++ b/packages/taroize/package.json
@@ -40,7 +40,6 @@
     "@babel/types": "^7.21.4",
     "babel-core": "^6.26.3",
     "babel-generator": "^6.26.1",
-    "babel-plugin-transform-commonjs": "^1.1.6",
     "babel-template": "^6.26.0",
     "babel-traverse": "^6.26.0",
     "babel-types": "^6.26.0",

--- a/packages/taroize/src/script.ts
+++ b/packages/taroize/src/script.ts
@@ -76,59 +76,6 @@ export function parseScript (
         )
       }
     },
-    VariableDeclaration (path) {
-      const variableDeclarator = path.node.declarations[0]
-      variableDeclarator.init
-      if (t.isVariableDeclarator(variableDeclarator)) {
-        // 去除commonjs转es6生成的var module = {exports: {},}
-        if (
-          t.isIdentifier(variableDeclarator.id) &&
-          variableDeclarator.id.name === 'module' &&
-          t.isObjectExpression(variableDeclarator.init)
-        ) {
-          const init: t.ObjectExpression = variableDeclarator.init
-          if (
-            init.properties &&
-            init.properties.length > 0 &&
-            t.isObjectProperty(init.properties[0]) &&
-            t.isIdentifier(init.properties[0].key) &&
-            init.properties[0].key.name === 'exports'
-          ) {
-            path.remove()
-          }
-        }
-        // 去除commonjs转es6生成的var exports = module.exports
-        if (
-          t.isIdentifier(variableDeclarator.id) &&
-          variableDeclarator.id.name === 'exports' &&
-          t.isMemberExpression(variableDeclarator.init)
-        ) {
-          const init: t.MemberExpression = variableDeclarator.init
-          if (
-            t.isIdentifier(init.object) &&
-            init.object.name === 'module' &&
-            t.isIdentifier(init.property) &&
-            init.property.name === 'exports'
-          ) {
-            path.remove()
-          }
-        }
-      }
-    },
-    ExportDefaultDeclaration (path) {
-      const declaration = path.node.declaration
-      // 去除commonjs转es6生成的export default module.exports
-      if (t.isMemberExpression(declaration)) {
-        if (
-          t.isIdentifier(declaration.object) &&
-          declaration.object.name === 'module' &&
-          t.isIdentifier(declaration.property) &&
-          declaration.property.name === 'exports'
-        ) {
-          path.remove()
-        }
-      }
-    },
   }
 
   traverse(ast, vistor)

--- a/packages/taroize/src/utils.ts
+++ b/packages/taroize/src/utils.ts
@@ -13,7 +13,6 @@ import presetTypescript from '@babel/preset-typescript'
 import { default as template } from '@babel/template'
 import { NodePath } from '@babel/traverse'
 import * as t from '@babel/types'
-import babel_plugin_transform_commonjs from 'babel-plugin-transform-commonjs'
 import { camelCase, capitalize } from 'lodash'
 
 export function isAliasThis (p: NodePath<t.Node>, name: string) {
@@ -61,7 +60,6 @@ export function parseCode (code: string, scriptPath?: string) {
           objectRestSpread,
           [decorators, { legacy: true }],
           dynamicImport,
-          babel_plugin_transform_commonjs,
         ],
       }) as { ast: t.File }
     ).ast
@@ -80,7 +78,6 @@ export function parseCode (code: string, scriptPath?: string) {
         objectRestSpread,
         [decorators, { legacy: true }],
         dynamicImport,
-        babel_plugin_transform_commonjs,
       ],
     }) as { ast: t.File }
   ).ast

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4388,9 +4388,6 @@ importers:
       babel-generator:
         specifier: ^6.26.1
         version: registry.npmjs.org/babel-generator@6.26.1
-      babel-plugin-transform-commonjs:
-        specifier: ^1.1.6
-        version: registry.npmjs.org/babel-plugin-transform-commonjs@1.1.6(@babel/core@7.21.8)
       babel-template:
         specifier: ^6.26.0
         version: registry.npmjs.org/babel-template@6.26.0
@@ -16063,6 +16060,8 @@ packages:
       babel-register: registry.npmjs.org/babel-register@6.26.0
       babylon: registry.npmjs.org/babylon@6.18.0
       require-from-string: registry.npmjs.org/require-from-string@2.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   registry.npmjs.org/babel-plugin-react-native-web@0.18.12:
@@ -40343,7 +40342,7 @@ packages:
       mime-types: registry.npmjs.org/mime-types@2.1.35
       range-parser: registry.npmjs.org/range-parser@1.2.1
       schema-utils: registry.npmjs.org/schema-utils@4.0.1
-      webpack: registry.npmjs.org/webpack@5.78.0
+      webpack: registry.npmjs.org/webpack@5.78.0(@swc/core@1.3.42)(webpack-cli@5.0.1)
 
   registry.npmjs.org/webpack-dev-server@3.11.3(webpack@4.46.0):
     resolution: {integrity: sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
导入导出commonjs转es6，代码回退


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
