### PR TITLE
fix: 修复template模板使用单个字母命名转换到H5报错问题

### DIFF
--- a/packages/taro-cli-convertor/package.json
+++ b/packages/taro-cli-convertor/package.json
@@ -40,6 +40,7 @@
     "@tarojs/helper": "workspace:*",
     "@tarojs/taroize": "workspace:*",
     "@tarojs/transformer-wx": "workspace:*",
+    "lodash": "^4.17.21",
     "postcss": "^8.4.18",
     "postcss-taro-unit-transform": "workspace:*",
     "prettier": "^2.7.1"

--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -34,6 +34,7 @@ import {
   handleThirdPartyLib,
   handleUnconvertDir,
   incrementId,
+  pascalName,
   transRelToAbsPath,
 } from './util'
 import { generateMinimalEscapeCode, hasTaroImport, isCommonjsModule } from './util/astConvert'
@@ -480,7 +481,7 @@ export default class Convertor {
             }
             if (imports && imports.length) {
               imports.forEach(({ name, ast, wxs }) => {
-                const importName = wxs ? name : pascalCase(name)
+                const importName = wxs ? name : pascalName(name)
                 if (componentClassName === importName) {
                   return
                 }

--- a/packages/taro-cli-convertor/src/util/index.ts
+++ b/packages/taro-cli-convertor/src/util/index.ts
@@ -10,11 +10,17 @@ import {
   resolveScriptPath,
   SCRIPT_EXT,
 } from '@tarojs/helper'
+import { camelCase, capitalize } from 'lodash'
 import * as path from 'path'
 
 import type * as t from '@babel/types'
 
 const NODE_MODULES = 'node_modules'
+
+export function pascalName (name: string) {
+  const str = camelCase(name)
+  return capitalize(str[0]) + str.slice(1)
+}
 
 export function getRootPath (): string {
   return path.resolve(__dirname, '../../')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1000,6 +1000,9 @@ importers:
       '@tarojs/transformer-wx':
         specifier: workspace:*
         version: link:../taro-transformer-wx
+      lodash:
+        specifier: ^4.17.21
+        version: registry.npmjs.org/lodash@4.17.21
       postcss:
         specifier: ^8.4.18
         version: registry.npmjs.org/postcss@8.4.23


### PR DESCRIPTION
/<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复template模板使用单个字母命名转换到H5报错问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
