### PR TITLE
fix: 兼容打包成commonjs格式的组件或页面转换

### DIFF
--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -36,7 +36,7 @@ import {
   incrementId,
   transRelToAbsPath,
 } from './util'
-import { generateMinimalEscapeCode, hasTaroImport, isCommonjsModule } from './util/astConvert'
+import { generateMinimalEscapeCode, hasTaroImport, isCommonjsImport, isCommonjsModule } from './util/astConvert'
 
 import type { ParserOptions } from '@babel/parser'
 import type { AppConfig, TabBar } from '@tarojs/taro'
@@ -376,13 +376,11 @@ export default class Convertor {
                   scriptComponents.push(componentName)
                 }
                 if (/^\S(\S)*Tmpl$/.test(componentName)) {
-                  const templateImport = imports.find(tmplImport => 
-                    tmplImport.name === `${componentName}`
-                  )
+                  const templateImport = imports.find((tmplImport) => tmplImport.name === `${componentName}`)
                   const templateFuncs = templateImport?.funcs
                   if (templateFuncs && templateFuncs.length > 0) {
                     const attributes: any[] = openingElement.node.attributes
-                    templateFuncs.forEach(templateFunc => {
+                    templateFuncs.forEach((templateFunc) => {
                       const memberExpression = t.memberExpression(t.thisExpression(), t.identifier(templateFunc))
                       const value = t.jsxExpressionContainer(memberExpression)
                       const name = t.jsxIdentifier(templateFunc)
@@ -420,7 +418,7 @@ export default class Convertor {
         },
         exit (astPath) {
           const bodyNode = astPath.get('body') as NodePath<t.Node>[]
-          const lastImport = bodyNode.filter((p) => p.isImportDeclaration()).pop()
+          const lastImport = bodyNode.filter((p) => p.isImportDeclaration() || isCommonjsImport(p)).pop()
           if (needInsertImportTaro && !hasTaroImport(bodyNode)) {
             // 根据模块类型（commonjs/es6) 确定导入taro模块的类型
             if (isCommonjsModule(bodyNode)) {
@@ -471,12 +469,20 @@ export default class Convertor {
           })
           if (lastImport) {
             if (importStylePath) {
-              lastImport.insertAfter(
-                t.importDeclaration(
-                  [],
-                  t.stringLiteral(promoteRelativePath(path.relative(sourceFilePath, importStylePath)))
+              if (isCommonjsModule(bodyNode)) {
+                lastImport.insertAfter(
+                  t.callExpression(t.identifier('require'), [
+                    t.stringLiteral(promoteRelativePath(path.relative(sourceFilePath, importStylePath))),
+                  ])
                 )
-              )
+              } else {
+                lastImport.insertAfter(
+                  t.importDeclaration(
+                    [],
+                    t.stringLiteral(promoteRelativePath(path.relative(sourceFilePath, importStylePath)))
+                  )
+                )
+              }
             }
             if (imports && imports.length) {
               imports.forEach(({ name, ast, wxs }) => {

--- a/packages/taro-cli-convertor/src/util/astConvert.ts
+++ b/packages/taro-cli-convertor/src/util/astConvert.ts
@@ -59,3 +59,22 @@ export function isCommonjsModule (bodyNode: NodePath<t.Node>[]) {
     return false
   })
 }
+
+/**
+ * 判断节点是否为commonjs的导入
+ *
+ * @param {NodePath<t.Node>} bodyNode
+ * @returns {boolean}
+ */
+export function isCommonjsImport (bodyNode: NodePath<t.Node>) {
+  if (bodyNode.isVariableDeclaration() && bodyNode.node.declarations.length === 1) {
+    const declaration: t.VariableDeclarator = bodyNode.node.declarations[0]
+    return (
+      declaration.init != null &&
+      declaration.init.type === 'CallExpression' &&
+      declaration.init.callee.type === 'Identifier' &&
+      declaration.init.callee.name === 'require'
+    )
+  }
+  return false
+}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
兼容打包成commonjs格式的组件或页面转换
场景：
组件打包成commonjs的格式，即在js中出现module.exports，如果导出的taro为esm的import形式，则出现了混用报错，此提交为兼容这类情况
![image](https://github.com/handsomeliuyang/taro/assets/110598219/07e793e2-5ad4-4385-9741-92b4f80302bd)


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
