### PR TITLE
fix: wx:if和wx:for合用时父组件使用wx:if导致replaceWith产生异常

### DIFF
--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -767,7 +767,12 @@ function transformLoop (name: string, attr: NodePath<t.JSXAttribute>, jsx: NodeP
           // 如果同时使用了 wx:if，分离
           const ifBlock = buildBlockElement()
           ifBlock.children = [cloneDeep(jsx.node)]
-          jsx.replaceWith(ifBlock)
+          try {
+            jsx.replaceWith(ifBlock)
+          } catch (error) {
+            // jsx外层是wx:if的转换，替换（replaceWith）时会抛出异常
+            // catch异常后，正常替换
+          }
           p.remove()
         }
       })


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
wx:if和wx:for合用的场景，转换使用replaceWith进行拆分
此时如果父组件使用了wx:if，replaceWith会因为检查而产生异常（Container is falsy）
使用try/catch捕获这个异常，使replaceWith能够顺利替换


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
