### PR TITLE
feat: 转换时生成sourceMap，获取源文件和目标文件的对应关系

### DIFF
--- a/packages/taro-cli-convertor/package.json
+++ b/packages/taro-cli-convertor/package.json
@@ -62,7 +62,8 @@
     "@tarojs/transformer-wx": "workspace:*",
     "postcss": "^8.4.18",
     "postcss-taro-unit-transform": "workspace:*",
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "source-map": "^0.7.4"
   },
   "devDependencies": {
     "@babel/parser": "^7.14.5",

--- a/packages/taro-cli-convertor/src/util/astConvert.ts
+++ b/packages/taro-cli-convertor/src/util/astConvert.ts
@@ -8,7 +8,8 @@ export function generateMinimalEscapeCode (ast: t.File) {
     jsescOption: {
       minimal: true,
     },
-  }).code
+    sourceMaps: true,
+  })
 }
 
 // 判断是否已经引入 @tarojs/taro

--- a/packages/taro-transformer-wx/package.json
+++ b/packages/taro-transformer-wx/package.json
@@ -74,6 +74,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babylon": "^6.18.0",
     "babel-plugin-transform-commonjs": "^1.1.6",
     "eslint-plugin-react": "7.10.0",
     "eslint-plugin-taro": "2.2.19",

--- a/packages/taroize/src/index.ts
+++ b/packages/taroize/src/index.ts
@@ -11,6 +11,7 @@ interface Option {
   script?: string
   scriptPath?: string
   wxml?: string
+  wxmlPath?: string
   path: string
   rootPath: string
   framework: 'react' | 'vue'
@@ -40,7 +41,7 @@ export function parse (option: Option) {
     }
   }
 
-  const { wxml, wxses, imports, refIds } = parseWXML(option.path, option.wxml)
+  const { wxml, wxses, imports, refIds } = parseWXML(option.path, option.wxml, false, option.wxmlPath)
   setting.sourceCode = option.script!
   const ast = parseScript(option.script, option.scriptPath, wxml as t.Expression, wxses, refIds, option.isApp)
 

--- a/packages/taroize/src/utils.ts
+++ b/packages/taroize/src/utils.ts
@@ -1,6 +1,4 @@
 import { codeFrameColumns } from '@babel/code-frame'
-import * as babel from '@babel/core'
-import { parse } from '@babel/parser'
 import classProperties from '@babel/plugin-proposal-class-properties'
 import decorators from '@babel/plugin-proposal-decorators'
 import objectRestSpread from '@babel/plugin-proposal-object-rest-spread'
@@ -9,10 +7,10 @@ import dynamicImport from '@babel/plugin-syntax-dynamic-import'
 import exponentiationOperator from '@babel/plugin-transform-exponentiation-operator'
 import flowStrip from '@babel/plugin-transform-flow-strip-types'
 import jsxPlugin from '@babel/plugin-transform-react-jsx'
-import presetTypescript from '@babel/preset-typescript'
 import { default as template } from '@babel/template'
 import { NodePath } from '@babel/traverse'
 import * as t from '@babel/types'
+import { parse } from 'babylon'
 import { camelCase, capitalize } from 'lodash'
 
 export function isAliasThis (p: NodePath<t.Node>, name: string) {
@@ -43,44 +41,19 @@ export function isValidVarName (str?: string) {
 }
 
 export function parseCode (code: string, scriptPath?: string) {
-  // 支持TS的解析
-  if (typeof scriptPath !== 'undefined') {
-    return (
-      babel.transformSync(code, {
-        ast: true,
-        sourceType: 'module',
-        filename: scriptPath,
-        presets: [presetTypescript],
-        plugins: [
-          classProperties,
-          jsxPlugin,
-          flowStrip,
-          exponentiationOperator,
-          asyncGenerators,
-          objectRestSpread,
-          [decorators, { legacy: true }],
-          dynamicImport,
-        ],
-      }) as { ast: t.File }
-    ).ast
-  }
-
-  return (
-    babel.transformSync(code, {
-      ast: true,
-      sourceType: 'module',
-      plugins: [
-        classProperties,
-        jsxPlugin,
-        flowStrip,
-        exponentiationOperator,
-        asyncGenerators,
-        objectRestSpread,
-        [decorators, { legacy: true }],
-        dynamicImport,
-      ],
-    }) as { ast: t.File }
-  ).ast
+  return parse(code, {
+    plugins: [
+      classProperties,
+      jsxPlugin,
+      flowStrip,
+      exponentiationOperator,
+      asyncGenerators,
+      objectRestSpread,
+      [decorators, { legacy: true }],
+      dynamicImport,
+    ],
+    sourceFilename: scriptPath,
+  }) as t.File
 }
 
 export const buildTemplate = (str: string) => {
@@ -299,4 +272,68 @@ export function isCommonjsModule (bodyNode) {
     }
     return false
   })
+}
+
+interface Position {
+  line: number
+  column: number
+}
+
+/**
+ * 将oldElement的location信息赋值给newElement的loc属性
+ *
+ * @param newElement 新节点
+ * @param oldElement 旧节点
+ * @returns newElement 添加位置信息的新节点
+ */
+export function addLocInfo (newElement, oldElement, filePath?: string) {
+  if (oldElement && oldElement.position) {
+    const position = oldElement.position
+    const locStart: Position = { line: position.start.line + 1, column: position.start.column }
+    const locEnd: Position = { line: position.end.line + 1, column: position.end.column }
+    newElement.loc = {
+      start: locStart,
+      end: locEnd,
+      filename: filePath,
+    }
+  }
+  return newElement
+}
+
+/**
+ * 判断字符串只包含换行符和空格
+ * 换行符，win: \r\n mac: \r
+ *
+ * @param { string } str
+ * @returns { boolean }
+ */
+export function isLineBreak (str: string) {
+  if (isNullOrUndefined(str)) {
+    return false
+  }
+
+  const regex = /^[\r\n\s]+$/
+  return regex.test(str)
+}
+
+/**
+ * 判断参数是否为null或undefined
+ *
+ * @param param
+ * @returns { boolean }
+ */
+export function isNullOrUndefined (param) {
+  return param === null || param === undefined
+}
+
+/**
+ * 获取不同操作系统下的换行符
+ *
+ * @returns { string } 换行符
+ */
+export function getLineBreak () {
+  if (process.platform === 'win32') {
+    return '\r\n'
+  }
+  return '\n'
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1009,6 +1009,9 @@ importers:
       prettier:
         specifier: ^2.7.1
         version: registry.npmjs.org/prettier@2.8.8
+      source-map:
+        specifier: ^0.7.4
+        version: registry.npmjs.org/source-map@0.7.4
     devDependencies:
       '@babel/parser':
         specifier: ^7.14.5
@@ -3694,6 +3697,9 @@ importers:
       babel-plugin-transform-flow-strip-types:
         specifier: ^6.22.0
         version: registry.npmjs.org/babel-plugin-transform-flow-strip-types@6.22.0
+      babylon:
+        specifier: ^6.18.0
+        version: registry.npmjs.org/babylon@6.18.0
       eslint-plugin-react:
         specifier: 7.10.0
         version: registry.npmjs.org/eslint-plugin-react@7.10.0(eslint@5.16.0)
@@ -41269,7 +41275,7 @@ packages:
       mime-types: registry.npmjs.org/mime-types@2.1.35
       range-parser: registry.npmjs.org/range-parser@1.2.1
       schema-utils: registry.npmjs.org/schema-utils@4.0.1
-      webpack: registry.npmjs.org/webpack@5.78.0
+      webpack: registry.npmjs.org/webpack@5.78.0(@swc/core@1.3.42)(webpack-cli@5.0.1)
 
   registry.npmjs.org/webpack-dev-server@3.11.3(webpack@4.46.0):
     resolution: {integrity: sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz}


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
1、从ast生成代码时不做prettier的格式化处理，会影响代码前后的映射关系
2、babel.transformSync生成的ast中loc无法设置filename，更换为babylon的parse
3、wxml解析成ast时将position属性转换为loc属性
4、wxml的ast与js的ast合并是格式会错乱，在行前增加6个空格保持格式对齐


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
