### PR TITLE
fix: 代码回退，修复import和解构符不支持的问题

### DIFF
--- a/packages/taro-transformer-wx/src/index.ts
+++ b/packages/taro-transformer-wx/src/index.ts
@@ -1,3 +1,4 @@
+import * as babel from '@babel/core'
 import generate from '@babel/generator'
 // import * as template from '@babel/template'
 // const template = require('babel-template')
@@ -11,7 +12,6 @@ import flowStrip from '@babel/plugin-transform-flow-strip-types'
 import jsxPlugin from '@babel/plugin-transform-react-jsx'
 import traverse, { Binding, NodePath } from '@babel/traverse'
 import * as t from '@babel/types'
-import { parse } from 'babylon'
 // import * as template from '@babel/template'
 // const template = require('babel-template')
 import { prettyPrint } from 'html'
@@ -211,20 +211,23 @@ export interface TransformResult extends Result {
 
 export type TransformOptions = Options
 
-function parseCode(code: string, sourcePath: string) {
-  return parse(code, {
-    plugins: [
-      classProperties,
-      jsxPlugin,
-      flowStrip,
-      exponentiationOperator,
-      asyncGenerators,
-      objectRestSpread,
-      [decorators, { legacy: true }],
-      dynamicImport,
-    ],
-    sourceFilename: sourcePath,
-  })
+function parseCode(code: string) {
+  return (
+    babel.transformSync(code, {
+      ast: true,
+      sourceType: 'module',
+      plugins: [
+        classProperties,
+        jsxPlugin,
+        flowStrip,
+        exponentiationOperator,
+        asyncGenerators,
+        objectRestSpread,
+        [decorators, { legacy: true }],
+        dynamicImport,
+      ],
+    }) as { ast: t.File }
+  ).ast
 }
 
 export default function transform(options: TransformOptions): TransformResult {
@@ -273,7 +276,7 @@ export default function transform(options: TransformOptions): TransformResult {
   // 将来升级到 babel@7 可以直接用 parse 而不是 transform
   // const ast = parser.parse(code, buildBabelTransformOptions() as any) as t.File
 
-  const ast = parseCode(code, options.sourcePath) as t.File
+  const ast = parseCode(code) as t.File
 
   // traverse(ast, {
   //   JSXElement (p) {

--- a/packages/taroize/src/script.ts
+++ b/packages/taroize/src/script.ts
@@ -46,7 +46,7 @@ export function parseScript (
     block.children = [returned as any]
     returned = block
   }
-  let ast = parseCode(script, scriptPath as string)
+  let ast = parseCode(script)
   let classDecl!: t.ClassDeclaration
   let foundWXInstance = false
   const vistor: Visitor = {

--- a/packages/taroize/src/utils.ts
+++ b/packages/taroize/src/utils.ts
@@ -1,4 +1,6 @@
 import { codeFrameColumns } from '@babel/code-frame'
+import * as babel from '@babel/core'
+import { parse } from '@babel/parser'
 import classProperties from '@babel/plugin-proposal-class-properties'
 import decorators from '@babel/plugin-proposal-decorators'
 import objectRestSpread from '@babel/plugin-proposal-object-rest-spread'
@@ -10,7 +12,6 @@ import jsxPlugin from '@babel/plugin-transform-react-jsx'
 import { default as template } from '@babel/template'
 import { NodePath } from '@babel/traverse'
 import * as t from '@babel/types'
-import { parse } from 'babylon'
 import { camelCase, capitalize } from 'lodash'
 
 export function isAliasThis (p: NodePath<t.Node>, name: string) {
@@ -40,20 +41,23 @@ export function isValidVarName (str?: string) {
   return true
 }
 
-export function parseCode (code: string, scriptPath?: string) {
-  return parse(code, {
-    plugins: [
-      classProperties,
-      jsxPlugin,
-      flowStrip,
-      exponentiationOperator,
-      asyncGenerators,
-      objectRestSpread,
-      [decorators, { legacy: true }],
-      dynamicImport,
-    ],
-    sourceFilename: scriptPath,
-  }) as t.File
+export function parseCode (code: string) {
+  return (
+    babel.transformSync(code, {
+      ast: true,
+      sourceType: 'module',
+      plugins: [
+        classProperties,
+        jsxPlugin,
+        flowStrip,
+        exponentiationOperator,
+        asyncGenerators,
+        objectRestSpread,
+        [decorators, { legacy: true }],
+        dynamicImport,
+      ],
+    }) as { ast: t.File }
+  ).ast
 }
 
 export const buildTemplate = (str: string) => {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
代码回退，修复import和解构符不支持的问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
