### PR TITLE
fix: 修复template中data数据为多个时转换异常

### DIFF
--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -928,7 +928,7 @@ function parseElement (element: Element): t.JSXElement {
             if (str.includes('...')) {
               // (...a) => {{a}}
               attr.value = `{{${str.slice(4, strLastIndex)}}}`
-            } else if (/^\(([A-Za-z]+)\)$/.test(str)) {
+            } else if (/^\(([A-Za-z,]+)\)$/.test(str)) {
               // (a) => {{a:a}}
               attr.value = `{{${str.replace(/^\(([A-Za-z]+)\)$/, '$1:$1')}}}`
             } else {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
修复template中data数据为多个时转换异常

微信源码：
<template is="huangye" data="{{name, age}}"/>

正常转换应该为：
<template is="huangye" data="{{name, name1}}"/>

当前异常转换：
<HuangyeTmpl data={(name, name1)}></HuangyeTmpl>



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
