### PR TITLE
fix: 修复template is为变量转换异常问题

### DIFF
--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -427,11 +427,16 @@ export default class Convertor {
                       t.isJSXAttribute(attr.node) &&
                       attr.node.name.name === 'is'
                   )
-                  // 处理<template is=字符串+变量 拼接的情况(组件的动态名称)
+                  // 处理<template is=包含变量的情况(组件的动态名称)
                   if (is && t.isJSXAttribute(is.node)) {
                     const value = is.node.value
                     if (value && t.isJSXExpressionContainer(value)) {
-                      if (t.isBinaryExpression(value.expression) && value.expression.operator === '+') {
+                      const expression = value.expression
+                      // 1、<template is={{var}}> 2、<template is="string{{var}}">
+                      if (
+                        t.isIdentifier(expression) ||
+                        (t.isBinaryExpression(expression) && expression.operator === '+')
+                      ) {
                         // 加上map, template原名和新名字的映射
                         const componentMapList: any[] = []
                         for (const order in imports) {
@@ -463,7 +468,7 @@ export default class Convertor {
                           const ComponentNameVariableDeclaration = t.variableDeclaration('let', [
                             t.variableDeclarator(
                               t.identifier('ComponentName'),
-                              t.memberExpression(t.identifier('ComponentMap'), value.expression, true)
+                              t.memberExpression(t.identifier('ComponentMap'), expression, true)
                             ),
                           ])
                           returnPath.insertBefore(ComponentNameVariableDeclaration)


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
修复template is为变量转换异常问题
修复的异常场景：is的value为变量，如下
<template is="{{core}}" ></template>

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
