### PR TITLE
fix: parseTemplate添加对path是否是JSXElement的判断，修复template和hidden合用时的转换错误

### DIFF
--- a/packages/taroize/src/template.ts
+++ b/packages/taroize/src/template.ts
@@ -109,7 +109,7 @@ export function preParseTemplate (path: NodePath<t.JSXElement>) {
 }
 
 export function parseTemplate (path: NodePath<t.JSXElement>, dirPath: string) {
-  if (!path.container) {
+  if (!path.container || !path.isJSXElement()) {
     return
   }
   printToLogFile(`funName: parseTemplate, path: ${path}, dirPath: ${dirPath} ${getLineBreak()}`)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
parseTemplate添加对path是否是JSXElement的判断，修复template和hidden合用时的转换错误


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [x] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
