### PR TITLE
fix: 修复template模板使用单个字母命名转换到H5报错问题和补充测试用例

### DIFF
--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -606,22 +606,21 @@ export default class Convertor {
             }
             if (imports && imports.length) {
               imports.forEach(({ name, ast, wxs }) => {
-                const importName = wxs ? name : pascalCase(name)
-                if (componentClassName === importName) {
+                if (componentClassName === name) {
                   return
                 }
                 const importPath = path.join(
                   self.importsDir,
-                  importName + (wxs ? self.wxsIncrementId() : '') + (self.isTsProject ? '.ts' : '.js')
+                  name + (wxs ? self.wxsIncrementId() : '') + (self.isTsProject ? '.ts' : '.js')
                 )
                 if (!self.hadBeenBuiltImports.has(importPath)) {
                   self.hadBeenBuiltImports.add(importPath)
                   self.writeFileToTaro(importPath, prettier.format(generateMinimalEscapeCode(ast), prettierJSConfig))
                 }
-                if (scriptComponents.indexOf(importName) !== -1 || (wxs && wxs === true)) {
+                if (scriptComponents.indexOf(name) !== -1 || (wxs && wxs === true)) {
                   lastImport.insertAfter(
                     template(
-                      `import ${importName} from '${promoteRelativePath(path.relative(outputFilePath, importPath))}'`,
+                      `import ${name} from '${promoteRelativePath(path.relative(outputFilePath, importPath))}'`,
                       babylonConfig
                     )() as t.Statement
                   )

--- a/packages/taroize/__tests__/template.test.ts
+++ b/packages/taroize/__tests__/template.test.ts
@@ -1,4 +1,5 @@
 import { globals } from '../src/global'
+import { buildTemplateName } from '../src/template'
 import { parseWXML } from '../src/wxml'
 import { generateMinimalEscapeCode } from './util'
 
@@ -101,6 +102,45 @@ describe('template.ts', () => {
       Object.defineProperty(globals, 'rootPath', {
         get: () => rootPath
       })
+    })
+  })
+
+  describe('templete中is属性解析', () => {
+    test('is属性为全小写', () => {
+      const inputValue = 'ash'
+      const tempName = buildTemplateName(inputValue)
+      expect(tempName).toBe('AshTmpl')
+    })
+
+    test('is属性为首字母大写', () => {
+      const inputValue = 'Aol'
+      const tempName = buildTemplateName(inputValue)
+      expect(tempName).toBe('AolTmpl')
+    })
+
+    test('is属性为大驼峰', () => {
+      const inputValue = 'AshMer'
+      const tempName = buildTemplateName(inputValue)
+      expect(tempName).toBe('AshMerTmpl')
+    })
+
+    test('is属性为单字母', () => {
+      const inputValue = 'a'
+      const tempName = buildTemplateName(inputValue)
+      expect(tempName).toBe('ATmpl')
+    })
+
+    test('is属性为小驼峰', () => {
+      const inputValue = 'anFish'
+      const tempName = buildTemplateName(inputValue)
+      expect(tempName).toBe('AnFishTmpl')
+    })
+
+    test('is属性为变量引用', () => {
+      const inputName = 'x'
+      const inputValue = `{{ ${ inputName } }}`
+      const tempName = buildTemplateName(inputValue)
+      expect(tempName).toBe('XTmpl')
     })
   })
 })


### PR DESCRIPTION
/<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复template模板使用单个字母命名转换到H5报错问题和补充测试用例

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
