### PR TITLE
fix: 修复template模板使用单个字母命名转换到H5报错问题和补充测试用例

### DIFF
--- a/packages/taro-cli-convertor/__tests__/__snapshots__/script.test.ts.snap
+++ b/packages/taro-cli-convertor/__tests__/__snapshots__/script.test.ts.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`page页面转换 template组件名转换 1`] = `
+"import withWeapp, { cacheOptions } from \\"@tarojs/with-weapp\\";
+import { Block } from \\"@tarojs/components\\";
+import React from \\"react\\";
+import Taro from \\"@tarojs/taro\\";
+import AnFishTmpl from 'taroConvert/src/imports/AnFishTmpl.js';
+import ATmpl from 'taroConvert/src/imports/ATmpl.js';
+import AshMerTmpl from 'taroConvert/src/imports/AshMerTmpl.js';
+import AolTmpl from 'taroConvert/src/imports/AolTmpl.js';
+import AshTmpl from 'taroConvert/src/imports/AshTmpl.js';
+cacheOptions.setOptionsToCache({});
+@withWeapp(cacheOptions.getOptionsFromCache())
+class _C extends React.Component {
+  render() {
+    return <Block>{
+        /*  template的name值为首字母大写且单个单词  */
+      }{
+        /*  template的name值为首字母大写且多个单词  */
+      }{
+        /*  template的name值为单字母  */
+      }{
+        /*  template的name值为小驼峰  */
+      }<AshTmpl></AshTmpl><AolTmpl></AolTmpl><AshMerTmpl></AshMerTmpl><ATmpl></ATmpl><AnFishTmpl></AnFishTmpl></Block>;
+  }
+}
+export default _C;"
+`;
+
 exports[`文件转换 project.config.json中添加配置miniprogramRoot后能够读取app.json进行convert 1`] = `
 Convertor {
   "components": Set {},

--- a/packages/taro-cli-convertor/__tests__/script.test.ts
+++ b/packages/taro-cli-convertor/__tests__/script.test.ts
@@ -173,3 +173,87 @@ describe('文件转换', () => {
     expect(paresResult).toMatchSnapshot()
   })
 })
+
+describe('page页面转换', () => {
+  let convert
+  let param: ITaroizeOptions
+  const entryJSON = { pages: ['pages/index/index'] }
+  beforeAll(() => {
+  /**
+     * json：index.json的内容
+     * path：index的根目录（文件路径)
+     * rootPath：小程序的根目录（文件路径）
+     * script：index.js的内容
+     * scriptPath：index.js的绝对路径
+     * wxml：index.html的内容
+     * logFilePath：convert.log的文件路径
+     */
+    param = {
+      json: '{}',
+      path: '',
+      rootPath: '',
+      script: '',
+      scriptPath: '',
+      wxml: '',
+      logFilePath: ''
+    }
+
+    jest.spyOn(Convertor.prototype, 'init').mockImplementation(() => {})
+
+    // new Convertot后会直接执行 init()，为确保 init() 在测试中通过采用 spyOn 去模拟
+    jest.spyOn(Convertor.prototype, 'getApp').mockImplementation(() => {
+      Convertor.prototype.entryJSON = entryJSON
+    })
+    jest.spyOn(Convertor.prototype, 'getPages').mockImplementation(() => {
+      Convertor.prototype.pages = new Set(entryJSON.pages)
+    })
+    convert = new Convertor('', false)
+    convert.pages = Convertor.prototype.pages
+  })
+  
+  test('template组件名转换', () => {
+    param.wxml = `
+      <!-- template的name值为全小写 -->
+      <template name="ash"></template>
+      <!-- template的name值为首字母大写且单个单词 -->
+      <template name="Aol"></template>
+      <!-- template的name值为首字母大写且多个单词 -->
+      <template name="AshMer"></template>
+      <!-- template的name值为单字母 -->
+      <template name="a"></template>
+      <!-- template的name值为小驼峰 -->
+      <template name="anFish"></template>
+      <template is="ash"/>
+      <template is="Aol"/>
+      <template is="AshMer"/>
+      <template is="a"/>
+      <template is="anFish"/>
+      `
+    param.path = 'import_template'
+
+    // 模拟writeFileToTaro文件写入方法，避免imports文件夹写入到taro工程
+    jest.spyOn(Convertor.prototype,'writeFileToTaro').mockImplementation(() => {})
+    
+    const taroizeResult = taroize({
+      ...param,
+      framework:'react'
+    })
+
+    /**
+     * sourceFilePath：需要转换的文件路径
+     * outputFilePath：转换输出路径
+     * importStylePath：style的文件路径
+     */
+    const { ast } = convert.parseAst({
+      ast: taroizeResult.ast,
+      sourceFilePath: '',
+      outputFilePath: '',
+      importStylePath: '',
+      depComponents: new Set(),
+      imports: taroizeResult.imports
+    })
+  
+    const jsCode = generateMinimalEscapeCode(ast)
+    expect(jsCode).toMatchSnapshot()
+  })
+})

--- a/packages/taro-cli-convertor/src/index.ts
+++ b/packages/taro-cli-convertor/src/index.ts
@@ -608,22 +608,21 @@ export default class Convertor {
             }
             if (imports && imports.length) {
               imports.forEach(({ name, ast, wxs }) => {
-                const importName = wxs ? name : pascalCase(name)
-                if (componentClassName === importName) {
+                if (componentClassName === name) {
                   return
                 }
                 const importPath = path.join(
                   self.importsDir,
-                  importName + (wxs ? self.wxsIncrementId() : '') + (self.isTsProject ? '.ts' : '.js')
+                  name + (wxs ? self.wxsIncrementId() : '') + (self.isTsProject ? '.ts' : '.js')
                 )
                 if (!self.hadBeenBuiltImports.has(importPath)) {
                   self.hadBeenBuiltImports.add(importPath)
                   self.writeFileToTaro(importPath, prettier.format(generateMinimalEscapeCode(ast), prettierJSConfig))
                 }
-                if (scriptComponents.indexOf(importName) !== -1 || (wxs && wxs === true)) {
+                if (scriptComponents.indexOf(name) !== -1 || (wxs && wxs === true)) {
                   lastImport.insertAfter(
                     template(
-                      `import ${importName} from '${promoteRelativePath(path.relative(outputFilePath, importPath))}'`,
+                      `import ${name} from '${promoteRelativePath(path.relative(outputFilePath, importPath))}'`,
                       babylonConfig
                     )() as t.Statement
                   )


### PR DESCRIPTION
/<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复template模板使用单个字母命名转换到H5报错问题和补充测试用例

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
