### PR TITLE
fix: 补充历史测试用例，修复一处转换错误

### DIFF
--- a/packages/taro-cli-convertor/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/taro-cli-convertor/__tests__/__snapshots__/index.test.ts.snap
@@ -16,6 +16,74 @@ class _C extends React.Component {
 export default _C;"
 `;
 
+exports[`parseAst 为data数据添加可选链操作符 1`] = `
+"import withWeapp, { cacheOptions } from \\"@tarojs/with-weapp\\";
+import { Block, View } from \\"@tarojs/components\\";
+import React from \\"react\\";
+import Taro from \\"@tarojs/taro\\";
+cacheOptions.setOptionsToCache({
+  data: {
+    testString: '',
+    testArray: [],
+    testUnArray: undefined
+  }
+});
+@withWeapp(cacheOptions.getOptionsFromCache())
+class _C extends React.Component {
+  render() {
+    const {
+      testString,
+      testArray,
+      testUnArray
+    } = this.data;
+    return <Block><View>{testString?.trim()}</View>{testArray?.[0]?.children?.map((item, index) => {
+        return <View>{item}</View>;
+      })}{testUnArray?.[1]?.children?.map((item, index) => {
+        return <View>{item}</View>;
+      })}</Block>;
+  }
+}
+export default _C;"
+`;
+
+exports[`parseAst 为setData数据添加可选链操作符 1`] = `
+"import withWeapp, { cacheOptions } from \\"@tarojs/with-weapp\\";
+import { Block, View } from \\"@tarojs/components\\";
+import React from \\"react\\";
+import Taro from \\"@tarojs/taro\\";
+cacheOptions.setOptionsToCache({
+  onLoad() {
+    let list = [];
+    let dcopy = [];
+    list.push({
+      children: [0, 1, 2, 3, 4, 5]
+    });
+    list.push({
+      children: [0, 1, 2, 3, 4]
+    });
+    this.setData({
+      list,
+      dcopy: [0, 1, 2, 3, 4, 5]
+    });
+  }
+});
+@withWeapp(cacheOptions.getOptionsFromCache())
+class _C extends React.Component {
+  render() {
+    const {
+      list,
+      dcopy
+    } = this.data;
+    return <Block>{list?.[0]?.children?.map((item, index) => {
+        return <View>{item}</View>;
+      })}{dcopy?.map((item, index) => {
+        return <View>{item}</View>;
+      })}</Block>;
+  }
+}
+export default _C;"
+`;
+
 exports[`parseAst 当使用e.target.dataset时引入工具函数 getTarget 1`] = `
 "import withWeapp, { cacheOptions, getTarget } from \\"@tarojs/with-weapp\\";
 import { Block, View, Button } from \\"@tarojs/components\\";
@@ -63,6 +131,41 @@ class _C extends React.Component {
       tagInfo
     } = this.data;
     return <Block><View>测试data-xxx-xxx写法</View><Button data-tag-name=\\"WX1314\\" data-tag-data={tagInfo} onClick={this.getMsg}>获取</Button><View>测试data-xxxXxxx 驼峰写法</View><Button data-tagname=\\"WX1314\\" data-tagdata={tagInfo} onClick={this.getMsg02}>获取</Button></Block>;
+  }
+}
+export default _C;"
+`;
+
+exports[`parseAst 模板按需导入 1`] = `
+"import withWeapp, { cacheOptions } from \\"@tarojs/with-weapp\\";
+import { Block } from \\"@tarojs/components\\";
+import React from \\"react\\";
+import Taro from \\"@tarojs/taro\\";
+import TemplateATmpl from 'taroConvert/src/imports/TemplateATmpl.js';
+cacheOptions.setOptionsToCache({});
+@withWeapp(cacheOptions.getOptionsFromCache())
+class _C extends React.Component {
+  render() {
+    return <TemplateATmpl></TemplateATmpl>;
+  }
+}
+export default _C;"
+`;
+
+exports[`parseAst 自定义组件按需导入 1`] = `
+"import withWeapp, { cacheOptions } from \\"@tarojs/with-weapp\\";
+import { Block } from \\"@tarojs/components\\";
+import React from \\"react\\";
+import Taro from \\"@tarojs/taro\\";
+import ComponentB from '../../../components/b';
+import ComponentA from '../../../components/a';
+cacheOptions.setOptionsToCache({});
+@withWeapp(cacheOptions.getOptionsFromCache())
+class _C extends React.Component {
+  render() {
+    return <Block><ComponentA name=\\"a\\"></ComponentA><ComponentB name=\\"b\\"></ComponentB>{
+        /*  <component-c name=\\"c\\" /> */
+      }</Block>;
   }
 }
 export default _C;"

--- a/packages/taro-cli-convertor/__tests__/index.test.ts
+++ b/packages/taro-cli-convertor/__tests__/index.test.ts
@@ -164,4 +164,187 @@ describe('parseAst', () => {
       })
     ).toThrow()
   })
+
+  // 测试数据添加可选链操作符
+  test('为data数据添加可选链操作符', () => {
+    param.script = `
+      Page({
+        data: {
+          testString: '',
+          testArray: [],
+          testUnArray: undefined,
+        },
+      })
+    `
+    param.wxml = `
+      <view>
+        {{testString.trim()}}
+      </view>
+
+      <view wx:for="{{testArray[0].children}}">
+        {{item}}
+      </view>
+    
+      <view wx:for="{{testUnArray[1].children}}">
+        {{item}}
+      </view>
+    `
+    param.path = 'data_optional'
+
+    // 转换页面js脚本
+    const taroizeResult = taroize({
+      ...param,
+      framework: 'react',
+    })
+
+    const { ast } = convert.parseAst({
+      ast: taroizeResult.ast,
+      sourceFilePath: '',
+      outputFilePath: '',
+      importStylePath: '',
+      depComponents: new Set(),
+      imports: [],
+    })
+
+    // 将ast转换为代码
+    const jsCode = generateMinimalEscapeCode(ast)
+    expect(jsCode).toMatchSnapshot()
+  })
+
+  test('为setData数据添加可选链操作符', () => {
+    param.script = `
+      Page({
+        onLoad() {
+          let list = []
+          let dcopy = []
+          list.push({
+            children: [0,1,2,3,4,5],
+          })
+          list.push({
+            children: [0,1,2,3,4],
+          })
+          this.setData({
+            list,
+            dcopy: [0,1,2,3,4,5],
+          })
+        },
+      })
+    `
+    param.wxml = `
+      <view wx:for="{{list[0].children}}">
+        {{item}}
+      </view>
+  
+      <view wx:for="{{dcopy}}">
+          {{item}}
+      </view>
+    `
+    param.path = 'setdata_optional'
+
+    // 转换页面js脚本
+    const taroizeResult = taroize({
+      ...param,
+      framework: 'react',
+    })
+
+    const { ast } = convert.parseAst({
+      ast: taroizeResult.ast,
+      sourceFilePath: '',
+      outputFilePath: '',
+      importStylePath: '',
+      depComponents: new Set(),
+      imports: [],
+    })
+
+    // 将ast转换为代码
+    const jsCode = generateMinimalEscapeCode(ast)
+    expect(jsCode).toMatchSnapshot()
+  })
+
+  // 按需导入
+  test('自定义组件按需导入', () => {
+    // 构造导入的组件集合depComponents
+    const depComponents = new Set([
+      {
+        name: 'component-a',
+        path: '/components/a'
+      },
+      {
+        name: 'component-b',
+        path: '/components/b'
+      },
+      {
+        name: 'component-c',
+        path: '/components/c'
+      }
+    ])
+    param.script = ``
+    param.wxml = `
+      <component-a name="a" />
+      <component-b name="b" />
+      <!-- <component-c name="c" /> -->
+    `
+    param.path = 'components_import'
+
+    const taroizeResult = taroize({
+      ...param,
+      framework: 'react',
+    })
+
+    const { ast } = convert.parseAst({
+      ast: taroizeResult.ast,
+      sourceFilePath: '',
+      outputFilePath: '',
+      importStylePath: '',
+      depComponents,
+      imports: [],
+    })
+
+    // 将ast转换为代码
+    const jsCode = generateMinimalEscapeCode(ast)
+    expect(jsCode).toMatchSnapshot()
+  })
+
+  test('模板按需导入', () => {
+    // index使用模板A，imports传回模板A、B、C
+    param.script = ``
+    param.wxml = `
+      <template is="template-a" />
+    `
+    param.path = 'templates_import'
+    jest.spyOn(convert.hadBeenBuiltImports, 'has').mockReturnValue(true)
+    const taroizeResult = taroize({
+      ...param,
+      framework: 'react',
+    })
+
+    // 按照实际情况，构造imports
+    const imports = [
+      {
+        ast: { type: 'File', program: [Object], comments: null, tokens: null },
+        name: 'TemplateATmpl',
+      },
+      {
+        ast: { type: 'File', program: [Object], comments: null, tokens: null },
+        name: 'TemplateBTmpl',
+      },
+      {
+        ast: { type: 'File', program: [Object], comments: null, tokens: null },
+        name: 'TemplateDTmpl',
+      }
+    ]
+
+    const { ast } = convert.parseAst({
+      ast: taroizeResult.ast,
+      sourceFilePath: '',
+      outputFilePath: '',
+      importStylePath: '',
+      depComponents: new Set(),
+      imports,
+    })
+
+    // 将ast转换为代码
+    const jsCode = generateMinimalEscapeCode(ast)
+    expect(jsCode).toMatchSnapshot()
+  })
 })

--- a/packages/taroize/__tests__/__snapshots__/template.test.ts.snap
+++ b/packages/taroize/__tests__/__snapshots__/template.test.ts.snap
@@ -1,5 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`template.ts template套用 同界面template套用 1`] = `
+"<FirstTagTmpl data={{
+  tagListFirst: tagListFirst,
+  tagListSecond: tagListSecond
+}}></FirstTagTmpl>"
+`;
+
+exports[`template.ts template套用 同界面template套用 2`] = `
+"import SecondTagTmpl from \\"./SecondTagTmpl\\";
+import { Block, View } from \\"@tarojs/components\\";
+import React from \\"react\\";
+import Taro from \\"@tarojs/taro\\";
+import withWeapp from \\"@tarojs/with-weapp\\";
+@withWeapp({})
+class FirstTagTmpl extends React.Component {
+  render() {
+    const {
+      data: {
+        tagListFirst,
+        index,
+        item,
+        tagListSecond
+      },
+      onClickFirstTag,
+      onClickSecndTag
+    } = this.props;
+    return <Block>{tagListFirst.map((item, index) => {
+        return <Block key={index}><View onClick={onClickFirstTag}>{item}</View></Block>;
+      })}<SecondTagTmpl data={{
+        tagListSecond: tagListSecond
+      }} onClickSecndTag={onClickSecndTag}></SecondTagTmpl></Block>;
+  }
+}
+export default FirstTagTmpl;"
+`;
+
+exports[`template.ts template套用 同界面template套用 3`] = `
+"import { Block, View } from \\"@tarojs/components\\";
+import React from \\"react\\";
+import Taro from \\"@tarojs/taro\\";
+import withWeapp from \\"@tarojs/with-weapp\\";
+@withWeapp({})
+class SecondTagTmpl extends React.Component {
+  render() {
+    const {
+      data: {
+        tagListSecond,
+        index,
+        item
+      },
+      onClickSecndTag
+    } = this.props;
+    return <Block>{tagListSecond.map((item, index) => {
+        return <Block key={index}><View onClick={onClickSecndTag}>{item}</View></Block>;
+      })}</Block>;
+  }
+}
+export default SecondTagTmpl;"
+`;
+
+exports[`template.ts template套用 通过import的套用 1`] = `
+"<TmplATmpl data={{
+  motto: motto,
+  mott: mott
+}}></TmplATmpl>"
+`;
+
+exports[`template.ts template套用 通过import的套用 2`] = `
+"import { Block, View, Button } from \\"@tarojs/components\\";
+import React from \\"react\\";
+import Taro from \\"@tarojs/taro\\";
+import withWeapp from \\"@tarojs/with-weapp\\";
+@withWeapp({})
+class TmplBTmpl extends React.Component {
+  render() {
+    const {
+      onClickC
+    } = this.props;
+    return <Block><View>this is template B</View><Button onClick={onClickC}>模板C的按钮</Button></Block>;
+  }
+}
+export default TmplBTmpl;"
+`;
+
+exports[`template.ts template套用 通过import的套用 3`] = `
+"import TmplBTmpl from \\"./TmplBTmpl\\";
+import { Block, View, Button } from \\"@tarojs/components\\";
+import React from \\"react\\";
+import Taro from \\"@tarojs/taro\\";
+import withWeapp from \\"@tarojs/with-weapp\\";
+@withWeapp({})
+class TmplATmpl extends React.Component {
+  render() {
+    const {
+      data: {
+        motto,
+        mott
+      },
+      onClickC
+    } = this.props;
+    return <Block><View>this is template A</View>{motto && <View>{mott}</View>}<TmplBTmpl onClickC={onClickC}></TmplBTmpl></Block>;
+  }
+}
+export default TmplATmpl;"
+`;
+
 exports[`template.ts 引入 import 正常情况 import src 为绝对路径 1`] = `
 "import { Block, View } from \\"@tarojs/components\\";
 import React from \\"react\\";

--- a/packages/taroize/__tests__/event.test.ts
+++ b/packages/taroize/__tests__/event.test.ts
@@ -477,3 +477,27 @@ describe('event convertor', () => {
     expect(wxml.openingElement.attributes[0].name.name).toBe('onTouchForceChange')
   })
 })
+
+// 主要测试，catch转换后，原先转换结果的this.privateStopNoop的包裹被去除
+describe('catch_event convetor', () => {
+  const option: Option = {
+    path: '',
+    wxml: ``
+  }
+
+  test('catchtap', () => {
+    option.path = 'catchtap'
+    option.wxml = `<button catchtap="handleTap">点击事件1</button>`
+    const { wxml }: any = parseWXML(option.path, option.wxml)
+    expect(wxml.openingElement.attributes[0].name.name).toBe('onClick')
+    expect(wxml.openingElement.attributes[0].value.expression.object.type).toBe('ThisExpression')
+  })
+
+  test('catch:tap', () => {
+    option.path = 'catch_tap'
+    option.wxml = `<button catch:tap="handleTap">点击事件1</button>`
+    const { wxml }: any = parseWXML(option.path, option.wxml)
+    expect(wxml.openingElement.attributes[0].name.name).toBe('onClick')
+    expect(wxml.openingElement.attributes[0].value.expression.object.type).toBe('ThisExpression')
+  })
+})

--- a/packages/taroize/__tests__/wxml.test.ts
+++ b/packages/taroize/__tests__/wxml.test.ts
@@ -744,3 +744,21 @@ describe('wx作用域属性解析', () => {
     expect(wxmlCode).toMatchSnapshot()
   })
 })
+
+describe('hidden属性解析', () => {
+  test('一般组件的hidden属性解析', () => {
+    option.wxml = `<view hidden="{{xx}}">{{xxx}}</view>`
+    option.path = 'hidden'
+    const { wxml }: any = parseWXML(option.path, option.wxml)
+    const wxmlCode = generateMinimalEscapeCode(wxml)
+    expect(wxmlCode).toEqual(`!xx && <View>{xxx}</View>`)
+  })
+
+  test('template的hidden属性解析', () => {
+    option.wxml = `<template is="{{name}}" hidden="{{xx}}" />`
+    option.path = 'hidden_template'
+    const { wxml }: any = parseWXML(option.path, option.wxml)
+    const wxmlCode = generateMinimalEscapeCode(wxml)
+    expect(wxmlCode).toEqual(`!xx && <Template is={name}></Template>`)
+  })
+})

--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -1106,9 +1106,9 @@ function parseElement (element: Element): t.JSXElement {
             if (str.includes('...')) {
               // (...a) => {{a}}
               attr.value = `{{${str.slice(4, strLastIndex)}}}`
-            } else if (/^\(([A-Za-z,]+)\)$/.test(str)) {
+            } else if (/^\(([A-Za-z,\s]+)\)$/.test(str)) {
               // (a) => {{a:a}}
-              attr.value = `{{${str.replace(/^\(([A-Za-z]+)\)$/, '$1:$1')}}}`
+              attr.value = `{{${str.slice(1, strLastIndex).replace(/([A-Za-z]+)/g, '$1:$1')}}}`
             } else {
               // (a:'a') => {{a:'a'}}
               attr.value = `{{${str.slice(1, strLastIndex)}}}`


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
补充历史测试用例：
1、data数据添加可选链操作符
2、组件、模板按需导入
3、模板套用，其中的数据和方法传递
4、部分catch事件，hidden属性解析

修复转换错误
形如(a ,b ,c...)转换，原先正则匹配缺失了对空格的检测


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
