### PR TITLE
fix: 修复setTabBarBadge可显示的中文字符最多两个

### DIFF
--- a/packages/taro-h5/src/api/ui/tab-bar.ts
+++ b/packages/taro-h5/src/api/ui/tab-bar.ts
@@ -217,7 +217,7 @@ export const setTabBarBadge: typeof Taro.setTabBarBadge = (options) => {
   return new Promise((resolve, reject) => {
     Taro.eventCenter.trigger('__taroSetTabBarBadge', {
       index,
-      text: text.length > 4 ? '...' : text,
+      text: text.replace(/[\u0391-\uFFE5]/g, 'aa').length > 4 ? '...' : text,
       successHandler: (res = {}) => handle.success(res, { resolve, reject }),
       errorHandler: (res = {}) => handle.fail(res, { resolve, reject })
     })


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
