### PR TITLE
fix: 内联style属性中绝对值小于1px/rpx转为rem

### DIFF
--- a/packages/taroize/__tests__/wxml.test.ts
+++ b/packages/taroize/__tests__/wxml.test.ts
@@ -802,10 +802,10 @@ describe('style属性的解析', () => {
     expect(contentInput).toBe(`<swiper-item style="transform: translate(0%, 0rem) translateZ(0rem);"></swiper-item>`)
   })
 
-  test('绝对值小于1的px转换成1rem', () => {
+  test('绝对值小于1的px/rpx转换成rem', () => {
     let contentInput = `<swiper-item style="margin-left: 0.5px;margin-right: -0.5rpx;"></swiper-item>`
     contentInput = convertStyleUnit(contentInput)
-    expect(contentInput).toBe(`<swiper-item style="margin-left: 1rem;margin-right: -1rem;"></swiper-item>`)
+    expect(contentInput).toBe(`<swiper-item style="margin-left: 0.025rem;margin-right: -0.0125rem;"></swiper-item>`)
   })
 
   test('style="height: calc(100vh - {{xxx}}rem)"，内联样式使用calc计算，包含变量，变量前有空格，转换后空格保留', () => {

--- a/packages/taroize/src/wxml.ts
+++ b/packages/taroize/src/wxml.ts
@@ -182,20 +182,13 @@ export function convertStyleUnit (value: string) {
           if (Number(size) === 0) {
             return match.replace(size, '0').replace(unit, 'rem')
           }
-          // 绝对值<1的非零值转十进制会被转为0, 这种情况直接把值认为是1
-          if (parseInt(size, 10) === 0) {
-            return match.replace(size, '1').replace(unit, 'rem')
-          }
-          return match.replace(size, parseInt(size, 10) / 20 + '').replace(unit, 'rem')
+          return match.replace(size, parseFloat(size) / 20 + '').replace(unit, 'rem')
         })
         .replace(/\s*-?([0-9.]+)(rpx)\b/gi, function (match, size, unit) {
           if (Number(size) === 0) {
             return match.replace(size, '0').replace(unit, 'rem')
           }
-          if (parseInt(size, 10) === 0) {
-            return match.replace(size, '1').replace(unit, 'rem')
-          }
-          return match.replace(size, parseInt(size, 10) / 40 + '').replace(unit, 'rem')
+          return match.replace(size, parseFloat(size) / 40 + '').replace(unit, 'rem')
         })
       // 把 xx="...{{参数}}rpx/px"的尺寸单位都转为rem,比如"{{参数}}rpx" -> "{{参数/40}}rem"
       tempValue = tempValue


### PR DESCRIPTION
/<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

原来：绝对值小于1px/rpx的强制转换为1rem
现在：绝对值小于1px/rpx的转换为rem，但值不变

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
