### PR TITLE
fix: wxss样式转换时为保证在h5显示比例相同需要乘以2倍

### DIFF
--- a/packages/postcss-unit-transform/index.js
+++ b/packages/postcss-unit-transform/index.js
@@ -7,7 +7,7 @@ function plugin (opts) {
     root.walkDecls(function (decl) {
       let value = decl.value
       value = value.replace(/\b-?(\d+(\.\d+)?)px\b/ig, function (size) {
-        return Number(size) === 0 ? '0px': parseFloat(size) + 'px'
+        return Number(size) === 0 ? '0px': parseFloat(size) * 2 + 'px'
       }).replace(/\b-?(\d+(\.\d+)?)rpx\b/ig, function (size) {
         return size + 'px'
       })


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
wxss样式转换时为保证在h5显示比例相同需要乘以2倍


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
