### PR TITLE
fix: 修复live-player全屏退出导航栏显示滞后问题

### DIFF
--- a/packages/taro-components/src/components/live-player/live-player.tsx
+++ b/packages/taro-components/src/components/live-player/live-player.tsx
@@ -256,6 +256,7 @@ export class LivePlayer implements ComponentInterface {
             direction: 0,
           })
         } else {
+          Taro.eventCenter.trigger('__taroExitFullScreen', {})
           this.onFullScreenChange.emit({
             fullScreen: this.isFullScreen,
             direction: 0,
@@ -460,11 +461,13 @@ export class LivePlayer implements ComponentInterface {
       fullScreen: this.isFullScreen,
       direction: 0,
     })
+    if (this.isFullScreen) {
+      Taro.eventCenter.trigger('__taroEnterFullScreen', {})
+    } 
     if (this.isFullScreen && !document[screenFn.fullscreenElement]) {
       try {
         setTimeout(() => {
           this.livePlayerRef[screenFn.requestFullscreen]({ navigationUI: 'auto' })
-          Taro.eventCenter.trigger('__taroEnterFullScreen', {})
         }, 0)
         return { errMsg: `requestFullScreen:ok` }
       } catch (e) {
@@ -472,7 +475,6 @@ export class LivePlayer implements ComponentInterface {
       }
     } else {
       try {
-        Taro.eventCenter.trigger('__taroExitFullScreen', {})
         document[screenFn.exitFullscreen]()
         return { errMsg: `exitFullScreen:ok` }
       } catch (e) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
-

**这个 PR 涉及以下平台:**

-
- [ ] Web 平台（H5）
- [ ] 鸿蒙（harmony）
