### PR TITLE
fix: 修复downloadTask中回调注册多次导致无法一次取消问题

### DIFF
--- a/packages/taro-mpharmony/src/api/network/download.ts
+++ b/packages/taro-mpharmony/src/api/network/download.ts
@@ -123,7 +123,7 @@ const createDownloadTask = ({ url, header, filePath, withCredentials = true, tim
    * 监听 HTTP Response Header 事件。会比请求完成事件更早
    * @param {HeadersReceivedCallback} callback HTTP Response Header 事件的回调函数
    */
-  const onHeadersReceived = callbackManager.headersReceived.add
+  const onHeadersReceived = callbackManager.headersReceived.addUnique
   /**
    * 取消监听 HTTP Response Header 事件
    * @param {HeadersReceivedCallback} callback HTTP Response Header 事件的回调函数
@@ -134,7 +134,7 @@ const createDownloadTask = ({ url, header, filePath, withCredentials = true, tim
    * 监听进度变化事件
    * @param {ProgressUpdateCallback} callback HTTP Response Header 事件的回调函数
    */
-  const onProgressUpdate = callbackManager.progressUpdate.add
+  const onProgressUpdate = callbackManager.progressUpdate.addUnique
   /**
    * 取消监听进度变化事件
    * @param {ProgressUpdateCallback} callback HTTP Response Header 事件的回调函数
@@ -157,7 +157,7 @@ const createDownloadTask = ({ url, header, filePath, withCredentials = true, tim
 
 /**
  * 下载文件资源到本地
- * 
+ *
  * @canUse downloadFile
  * @__object [url, filePath, header, timeout, withCredentials]
  * @__success [filePath, statusCode, tempFilePath, header, dataLength, cookies, profile]

--- a/packages/taro-mpharmony/src/utils/handler.ts
+++ b/packages/taro-mpharmony/src/utils/handler.ts
@@ -72,6 +72,16 @@ type TCallbackManagerUnit<T extends unknown[] = unknown[]> = TCallbackManagerFun
 export class CallbackManager<T extends unknown[] = unknown[]> {
   callbacks: TCallbackManagerUnit<T>[] = []
 
+  /** 判断是否有相同的回调 */
+  hasSameCallback = (opt: TCallbackManagerUnit<T>) => {
+    return this.callbacks.indexOf(opt) !== -1
+  }
+
+  /** 添加不可重复的回调 */
+  addUnique = (opt?: TCallbackManagerUnit<T>) => {
+    if (opt && !this.hasSameCallback(opt)) this.callbacks.push(opt)
+  }
+
   /** 添加回调 */
   add = (opt?: TCallbackManagerUnit<T>) => {
     if (opt) this.callbacks.push(opt)


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

在downloadTask中回调注册前增加一次判断，过滤掉已经注册的回调函数

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
