### PR TITLE
【harmony-hybrid】chooseMedia适配两种实现方式，由sizeType控制

### DIFF
--- a/examples/mini-program-example/src/pages/api/media/video/index.tsx
+++ b/examples/mini-program-example/src/pages/api/media/video/index.tsx
@@ -221,36 +221,6 @@ export default class Index extends React.Component {
         },
       },
       {
-        id: 'chooseMedium',
-        inputData: {
-          count: 9,
-          mediaType: ['image'],
-          sourceType: ['album', 'camera'],
-          maxDuration: 30,
-          sizeType: ['original', 'compressed'],
-          camera: 'back',
-          mediaId: '',
-          takingSupported: false,
-          editSupported: false,
-          searchSupported: false,
-        },
-        func: (apiIndex, data) => {
-          TestConsole.consoleTest('chooseMedium')
-          // @ts-ignore
-          Taro.chooseMedium({
-            ...data,
-            success: (res) => {
-              TestConsole.consoleSuccess.call(this, res, apiIndex)
-            },
-            fail: (res) => {
-              TestConsole.consoleFail.call(this, res, apiIndex)
-            },
-          }).then((res) => {
-            TestConsole.consoleResult.call(this, res, apiIndex)
-          })
-        },
-      },
-      {
         id: 'createVideoContext',
         func: (apiIndex) => {
           TestConsole.consoleTest('createVideoContext')

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/media/video/chooseMedia/chooseMedia.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/media/video/chooseMedia/chooseMedia.ts
@@ -1,9 +1,9 @@
 import Taro from '@tarojs/taro'
 import { showActionSheet } from '@tarojs/taro-h5'
 
-import native from '../../NativeApi'
-import { shouldBeObject } from '../../utils'
-import { MethodHandler } from '../../utils/handler'
+import native from '../../../NativeApi'
+import { shouldBeObject } from '../../../utils'
+import { MethodHandler } from '../../../utils/handler'
 
 /**
  * 拍摄或从手机相册中选择图片或视频

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/media/video/chooseMedia/chooseMedium.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/media/video/chooseMedia/chooseMedium.ts
@@ -1,8 +1,8 @@
 import { showActionSheet } from '@tarojs/taro-h5'
 
-import native from '../../NativeApi'
-import { shouldBeObject } from '../../utils'
-import { MethodHandler } from '../../utils/handler'
+import native from '../../../NativeApi'
+import { shouldBeObject } from '../../../utils'
+import { MethodHandler } from '../../../utils/handler'
 
 namespace chooseMedium {
   export interface Option {
@@ -85,12 +85,6 @@ namespace chooseMedium {
     thumbTempFilePath: string
     /** 选择的文件的类型 */
     fileType: string
-    /** 相册中是否支持拍照 */
-    takingSupported?: boolean
-    /** 相册中是否支持编辑照片 */
-    editSupported?: boolean
-    /** 相册中是否支持搜索 */
-    searchSupported?: boolean
   }
   export interface mediaType {
     /** 只能拍摄视频或从相册选择视频 */

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/media/video/chooseMedia/index.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/media/video/chooseMedia/index.ts
@@ -1,0 +1,6 @@
+import { chooseMedia as chooseMediaAlbum } from './chooseMedia'
+import { chooseMedium as chooseMediaPicker } from './chooseMedium'
+
+export const chooseMedia = (options: any, usePicker: boolean = true) => {
+  return usePicker ? chooseMediaPicker(options) : chooseMediaAlbum(options)
+}

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/media/video/index.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/media/video/index.ts
@@ -15,8 +15,7 @@ export { createVideoContext } from '@tarojs/taro-h5'
 /**
  * 拍摄视频或从手机相册中选视频。
  */
-export * from './chooseMedia'
-export * from './chooseMedium'
+export * from './chooseMedia/index'
 
 /**
  * VideoContext 实例


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

chooseMedia适配两种实现方式，由sizeType是否传入控制

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [x] 鸿蒙（harmony）
