### PR TITLE
fix: [H5] video组件mute={true}时，静音按钮状态显示为非静音

### DIFF
--- a/packages/taro-components/src/components/video/video.tsx
+++ b/packages/taro-components/src/components/video/video.tsx
@@ -188,6 +188,7 @@ export class Video implements ComponentInterface {
 
   componentWillLoad () {
     this._enableDanmu = this.enableDanmu
+    this.isMute = this.muted
   }
 
   componentDidLoad () {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

video组件mute={true}时，静音按钮状态显示为非静音

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [x] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
