### PR TITLE
fix: 部分API使用的原生侧api废弃，改为继承h5

### DIFF
--- a/packages/taro-platform-harmony-hybrid/src/api/apis/device/wifi/connectWifi.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/device/wifi/connectWifi.ts
@@ -1,6 +1,0 @@
-/**
- * 连接 Wi-Fi
- *
- * @canNotUse connectWifi
- */
-export { connectWifi } from '@tarojs/taro-h5'

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/device/wifi/getWifiList.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/device/wifi/getWifiList.ts
@@ -1,6 +1,0 @@
-/**
- * 请求获取 Wi-Fi 列表
- *
- * @canNotUse getWifiList
- */
-export { getWifiList } from '@tarojs/taro-h5'

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/device/wifi/index.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/device/wifi/index.ts
@@ -1,14 +1,10 @@
-export * from './connectWifi'
 export * from './getConnectedWifi'
-export * from './getWifiList'
 export * from './offGetWifiList'
 export * from './offWifiConnected'
 export * from './offWifiConnectedWithPartialInfo'
 export * from './onGetWifiList'
 export * from './onWifiConnected'
 export * from './onWifiConnectedWithPartialInfo'
-export * from './startWifi'
-export * from './stopWifi'
 
 /**
  * Wifi 信息(native 返回)

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/device/wifi/startWifi.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/device/wifi/startWifi.ts
@@ -1,6 +1,0 @@
-/**
- * 初始化 Wi-Fi 模块
- *
- * @canNotUse startWifi
- */
-export { startWifi } from '@tarojs/taro-h5'

--- a/packages/taro-platform-harmony-hybrid/src/api/apis/device/wifi/stopWifi.ts
+++ b/packages/taro-platform-harmony-hybrid/src/api/apis/device/wifi/stopWifi.ts
@@ -1,6 +1,0 @@
-/**
- * 关闭 Wi-Fi 模块
- *
- * @canNotUse stopWifi
- */
-export { stopWifi } from '@tarojs/taro-h5'


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
部分API使用的原生侧api废弃，改为继承h5


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
